### PR TITLE
Permission fixes for the Store and Publisher

### DIFF
--- a/apps/publisher/controllers/test.jag
+++ b/apps/publisher/controllers/test.jag
@@ -1,8 +1,19 @@
 <%
 var rxtAPI = require('rxt');
 var log = new Log();
-// var context = rxtAPI.core.createUserAssetContext(session, 'gadget');
-// var um = context.userManager;
+var context = rxtAPI.core.createUserAssetContext(session, 'gadget');
+var um = context.userManager;
+
+log.info(um.roleExists('Internal/publisher'));
+log.info(um.roleExists('iii'));
+
+var testRole = 'es.store.anon.user';
+if(!um.roleExists(testRole)){
+    log.info('Creating test role '+testRole);
+    um.addRole(testRole,[],[]);
+}
+log.info(um.roleExists(testRole));
+
 // var authorizer = um.authorizer;
 // var server = require('store').server;
 // var user = um.getUser('user1'); //server.current(session);
@@ -34,18 +45,18 @@ var log = new Log();
 // log.info('##############');
 
 //rxtAPI.permissions.force(-1234);
-var permissions = rxtAPI.permissions;
+// var permissions = rxtAPI.permissions;
 
-log.info('### Asset Check ###');
+// log.info('### Asset Check ###');
 
-log.info('*** user3 ***');
-log.info('Is authorized to view create page of SITES? '+permissions.hasAssetPermission('ASSET_CREATE','site',-1234,'user4'));
-log.info('Is authorized to view list page of SITES? '+permissions.hasAssetPermission('ASSET_LIST','site',-1234,'user4'));
-log.info('Is authorized to view lifecycle page of SITES? '+permissions.hasAssetPermission('ASSET_LIFECYCLE','site',-1234,'user4'));
+// log.info('*** user3 ***');
+// log.info('Is authorized to view create page of SITES? '+permissions.hasAssetPermission('ASSET_CREATE','site',-1234,'user4'));
+// log.info('Is authorized to view list page of SITES? '+permissions.hasAssetPermission('ASSET_LIST','site',-1234,'user4'));
+// log.info('Is authorized to view lifecycle page of SITES? '+permissions.hasAssetPermission('ASSET_LIFECYCLE','site',-1234,'user4'));
 
-log.info('Is authorized to view create page of GADGETS? '+permissions.hasAssetPermission('ASSET_CREATE','gadget',-1234,'user4'));
-log.info('Is authorized to view list page of GADGETS? '+permissions.hasAssetPermission('ASSET_LIST','gadget',-1234,'user4'));
-log.info('Is authorized to view lifecycle page of GADGETS? '+permissions.hasAssetPermission('ASSET_LIFECYCLE','gadget',-1234,'user4'));
+// log.info('Is authorized to view create page of GADGETS? '+permissions.hasAssetPermission('ASSET_CREATE','gadget',-1234,'user4'));
+// log.info('Is authorized to view list page of GADGETS? '+permissions.hasAssetPermission('ASSET_LIST','gadget',-1234,'user4'));
+// log.info('Is authorized to view lifecycle page of GADGETS? '+permissions.hasAssetPermission('ASSET_LIFECYCLE','gadget',-1234,'user4'));
 
 
 //log.info('*** admin ***');

--- a/apps/publisher/extensions/assets/default/asset.js
+++ b/apps/publisher/extensions/assets/default/asset.js
@@ -107,7 +107,8 @@ asset.server = function(ctx) {
             }, {
                 title: 'Update ' + type,
                 url: 'update',
-                path: 'update.jag'
+                path: 'update.jag',
+                permission:'ASSET_UPDATE'
             }, {
                 title: 'Details ' + type,
                 url: 'details',
@@ -223,7 +224,7 @@ asset.renderer = function(ctx) {
         var navList = util.navList();
         var isLCViewEnabled = ctx.rxtManager.isLifecycleViewEnabled(ctx.assetType);
 
-        if(permissionAPI.hasAssetPermission(permissionAPI.ASSET_CREATE,ctx.assetType,ctx.session)){
+        if(permissionAPI.hasAssetPermission(permissionAPI.ASSET_UPDATE,ctx.assetType,ctx.session)){
             navList.push('Edit', 'btn-edit', util.buildUrl('update') + '/' + id);
         }
 

--- a/apps/store/extensions/app/store-common/app.js
+++ b/apps/store/extensions/app/store-common/app.js
@@ -27,7 +27,8 @@ app.server = function(ctx) {
                 title:'Store | My Items',
                 url:'my-items',
                 path:'my_items.jag',
-                secured:true
+                secured:true,
+                permission:'APP_MYITEMS'
             }]
         },
         configs: {

--- a/apps/store/extensions/assets/default/asset.js
+++ b/apps/store/extensions/assets/default/asset.js
@@ -79,11 +79,13 @@ asset.server = function(ctx) {
             pages: [{
                 title: 'Store |  ' + typeSingularLabel,
                 url: 'details',
-                path: 'details.jag'
+                path: 'details.jag',
+                permission:'ASSET_DETAILS'
             }, {
                 title: 'Store | ' + typeSingularLabel,
                 url: 'list',
-                path: 'list.jag'
+                path: 'list.jag',
+                permission:'ASSET_LIST'
             }, {
                 title: 'Store | ' + typeSingularLabel,
                 url: 'subscriptions',

--- a/apps/store/extensions/assets/default/permissions.js
+++ b/apps/store/extensions/assets/default/permissions.js
@@ -15,6 +15,9 @@ var tenantLoad = function(ctx) {
     var reviewPermission = function(type) {
         return Utils.assetFeaturePermissionString('reviews', type);
     };
+    var myitemsPermission = function(){
+        return Utils.appFeaturePermissionString('myitems');
+    };
     var populateAssetPermissions = function(tenantId) {
         var types = rxtManager.listRxtTypes();
         var type;
@@ -38,10 +41,21 @@ var tenantLoad = function(ctx) {
         }
     };
     var populateAppPermissions = function(tenantId) {
-        var permissions = {};
+        var permissions = Permissions;
         var permission;
         var key;
-        var features = ['myassets'];
+        var features = ['myitems'];
+        var feature;
+        var obj = {};
+        for(var index = 0; index < features.length; index++){
+            feature = features[index];
+            key = Utils.appFeaturePermissionKey(feature);
+            permission = Utils.appFeaturePermissionString(feature);
+            permissions[key] = permission;
+            obj[key] = permission;
+            //log.info('New app permission: '+key+' : '+permission);
+        }
+        Utils.registerPermissions(obj,tenantId);
     };
     var assignAllPermissionsToDefaultRole = function() {
         var types = rxtManager.listRxtTypes();
@@ -54,6 +68,7 @@ var tenantLoad = function(ctx) {
             permissions.ASSET_LIST = listPermission(type);
             permissions.ASSET_BOOKMARK = bookmarkPermission(type);
             permissions.ASSET_REVIEWS = reviewPermission(type);
+            permissions.APP_MYITEMS = myitemsPermission();
             Utils.addPermissionsToRole(permissions, DEFAULT_ROLE, tenantId);
         }
     };
@@ -65,6 +80,7 @@ var tenantLoad = function(ctx) {
             type = types[index];
             permissions = {};
             permissions.ASSET_LIST = listPermission(type);
+            permissions.ASSET_REVIEWS = reviewPermission(type);
             Utils.addPermissionsToRole(permissions, ANON_ROLE, tenantId);
         }
     };
@@ -94,8 +110,12 @@ var tenantLoad = function(ctx) {
         }
         return ctx.utils.assetFeaturePermissionString('list', ctx.type);
     };
+    Permissions.APP_MYITEMS = function(ctx){
+        return ctx.utils.appFeaturePermissionString('myitems');
+    };
     log.info('### registering permissions not in the WSO2 permission tree ###');
     populateAssetPermissions(tenantId);
+    populateAppPermissions(tenantId);
     log.info('### adding permissions to role: ' + DEFAULT_ROLE + ' ###');
     assignAllPermissionsToDefaultRole();
     log.info('### registering store anonymous role : ' + ANON_ROLE + ' ###');

--- a/apps/store/extensions/assets/default/permissions.js
+++ b/apps/store/extensions/assets/default/permissions.js
@@ -5,6 +5,7 @@ var tenantLoad = function(ctx) {
     var rxtManager = ctx.rxtManager;
     var DEFAULT_ROLE = 'Internal/store';
     var tenantId = ctx.tenantId;
+    var ANON_ROLE = Utils.anonRole(tenantId);
     var listPermission = function(type) {
         return '/permission/admin/manage/resources/govern/' + type + '/list';
     };
@@ -31,4 +32,8 @@ var tenantLoad = function(ctx) {
     log.info('### Populating permissions to ' + DEFAULT_ROLE + ' ###');
     assignAllPermissionsToDefaultRole();
     log.info('### Done ###');
+
+    log.info('Anon role added ? '+Utils.addRole(ANON_ROLE));
+    log.info('update permission for assets: '+Utils.assetFeaturePermissionString('/update', 'gadget'));
+    log.info(Utils.assetFeaturePermissionKey('update','gadget'));
 };

--- a/apps/store/extensions/assets/default/permissions.js
+++ b/apps/store/extensions/assets/default/permissions.js
@@ -33,7 +33,7 @@ var tenantLoad = function(ctx) {
     assignAllPermissionsToDefaultRole();
     log.info('### Done ###');
 
-    log.info('Anon role added ? '+Utils.addRole(ANON_ROLE));
-    log.info('update permission for assets: '+Utils.assetFeaturePermissionString('/update', 'gadget'));
-    log.info(Utils.assetFeaturePermissionKey('update','gadget'));
+    //log.info('Anon role added ? '+Utils.addRole(ANON_ROLE));
+    //log.info('update permission for assets: '+Utils.assetFeaturePermissionString('/update', 'gadget'));
+    //log.info(Utils.assetFeaturePermissionKey('update','gadget'));
 };

--- a/apps/store/extensions/assets/default/permissions.js
+++ b/apps/store/extensions/assets/default/permissions.js
@@ -7,7 +7,41 @@ var tenantLoad = function(ctx) {
     var tenantId = ctx.tenantId;
     var ANON_ROLE = Utils.anonRole(tenantId);
     var listPermission = function(type) {
-        return '/permission/admin/manage/resources/govern/' + type + '/list';
+        return Utils.assetFeaturePermissionString('list', type); //'/permission/admin/manage/resources/govern/' + type + '/list';
+    };
+    var bookmarkPermission = function(type) {
+        return Utils.assetFeaturePermissionString('bookmark', type);
+    };
+    var reviewPermission = function(type) {
+        return Utils.assetFeaturePermissionString('reviews', type);
+    };
+    var populateAssetPermissions = function(tenantId) {
+        var types = rxtManager.listRxtTypes();
+        var type;
+        var permissions = Permissions;
+        var permission;
+        var features = ['list', 'bookmark', 'reviews'];
+        var feature;
+        var key;
+        var obj;
+        for (var index = 0; index < types.length; index++) {
+            obj = {};
+            type = types[index];
+            for (var featureIndex = 0; featureIndex < features.length; featureIndex++) {
+                feature = features[featureIndex];
+                key = Utils.assetFeaturePermissionKey(feature, type);
+                permission = Utils.assetFeaturePermissionString(feature, type);
+                obj[key] = permission;
+                permissions[key] = permission;
+            }
+            Utils.registerPermissions(obj, tenantId);
+        }
+    };
+    var populateAppPermissions = function(tenantId) {
+        var permissions = {};
+        var permission;
+        var key;
+        var features = ['myassets'];
     };
     var assignAllPermissionsToDefaultRole = function() {
         var types = rxtManager.listRxtTypes();
@@ -17,23 +51,56 @@ var tenantLoad = function(ctx) {
         for (var index = 0; index < types.length; index++) {
             type = types[index];
             permissions = {};
-
             permissions.ASSET_LIST = listPermission(type);
+            permissions.ASSET_BOOKMARK = bookmarkPermission(type);
+            permissions.ASSET_REVIEWS = reviewPermission(type);
             Utils.addPermissionsToRole(permissions, DEFAULT_ROLE, tenantId);
         }
     };
-    log.info('### Populating default permissions ###');
+    var assignPermissionsToAnonRole = function(tenantId) {
+        var types = rxtManager.listRxtTypes();
+        var type;
+        var permissions;
+        for (var index = 0; index < types.length; index++) {
+            type = types[index];
+            permissions = {};
+            permissions.ASSET_LIST = listPermission(type);
+            Utils.addPermissionsToRole(permissions, ANON_ROLE, tenantId);
+        }
+    };
+    log.info('### Starting permission operations ###');
+    log.info('### registering default permissions ###');
     Permissions.ASSET_LIST = function(ctx) {
         if (!ctx.type) {
             throw 'Unable to resolve type to determine the ASSET_LIST permission';
         }
-        return '/permission/admin/manage/resources/govern/' + ctx.type + '/list';
+        return ctx.utils.assetFeaturePermissionString('list', ctx.type);
     };
-    log.info('### Populating permissions to ' + DEFAULT_ROLE + ' ###');
+    Permissions.ASSET_BOOKMARK = function(ctx) {
+        if (!ctx.type) {
+            throw 'Unable to resolve type to determine the ASSET_BOOKMARK permission';
+        }
+        return ctx.utils.assetFeaturePermissionString('bookmark', ctx.type);
+    };
+    Permissions.ASSET_REVIEWS = function(ctx) {
+        if (!ctx.type) {
+            throw 'Unable to resolve type to determine the ASSET_REVIEWS permission';
+        }
+        return ctx.utils.assetFeaturePermissionString('reviews', ctx.type);
+    };
+    Permissions.ASSET_DETAILS = function(ctx) {
+        if(!ctx.type) {
+            throw 'Unable to resolve type to determine the ASSET_DETAILS permission';
+        }
+        return ctx.utils.assetFeaturePermissionString('list', ctx.type);
+    };
+    log.info('### registering permissions not in the WSO2 permission tree ###');
+    populateAssetPermissions(tenantId);
+    log.info('### adding permissions to role: ' + DEFAULT_ROLE + ' ###');
     assignAllPermissionsToDefaultRole();
-    log.info('### Done ###');
-
-    //log.info('Anon role added ? '+Utils.addRole(ANON_ROLE));
-    //log.info('update permission for assets: '+Utils.assetFeaturePermissionString('/update', 'gadget'));
-    //log.info(Utils.assetFeaturePermissionKey('update','gadget'));
+    log.info('### registering store anonymous role : ' + ANON_ROLE + ' ###');
+    log.info('anonymous role registered successfully : ' + Utils.addRole(ANON_ROLE));
+    log.info('### assigning store permissions to anonymous role ###');
+    assignPermissionsToAnonRole(tenantId);
+    log.info('### Permission operations have finished ###');
 };

--- a/apps/store/themes/store/partials/asset.hbs
+++ b/apps/store/themes/store/partials/asset.hbs
@@ -27,7 +27,9 @@
                     <div class="col-lg-5  padding-top right asset-rating margin-left-double">
                     </div>
                 </div>
-                 {{>asset-utilization ../..}}
+                 {{#hasAssetPermission . key="ASSET_BOOKMARK" type=../../rxt.shortName username=../../cuser.username tenantId=../../cuser.tenantId}}
+                    {{>asset-utilization ../../..}}
+                 {{/hasAssetPermission}}
                  {{> asset-version-info ../..}}
              </div>
                 <!-- end of asset details-->

--- a/apps/store/themes/store/partials/asset.hbs
+++ b/apps/store/themes/store/partials/asset.hbs
@@ -50,9 +50,11 @@
                         <li class="active">
                             <a href="#tab-properties" data-toggle="tab" data-type="basic">{{t "Description"}}</a>
                         </li>
+                        {{#hasAssetPermission . key="ASSET_REVIEWS" type=../../rxt.shortName username=../../cuser.username tenantId=../../cuser.tenantId}}
                         <li>
                             <a href="#tab-reviews" data-toggle="tab" data-type="comments">{{t "User Reviews"}}</a>
                         </li>
+                        {{/hasAssetPermission}}
                         <li>
                             <a href="#tab-share" data-toggle="tab" data-type="basic">{{t "Share"}}</a>
                         </li>
@@ -69,18 +71,20 @@
                                 {{>share ../..}}
                             </div>
                         </div>
+                        {{#hasAssetPermission . key="ASSET_REVIEWS" type=../../rxt.shortName username=../../cuser.username tenantId=../../cuser.tenantId}}
                         <div class="tab-pane" id="tab-reviews">
-                             {{#if ../../features.social.enabled}}
+                             {{#if ../../../features.social.enabled}}
                                 <iframe name="socialIfr" id="socialIfr"
-                                    src="{{../../../features.social.keys.socialAppUrl}}?target={{../../../rxt.shortName}}:{{../../id}}&user={{../../../cuser.username}}&urlDomain={{../../../features.social.keys.urlDomain}}"
-                                    width="100%" height="100%" style="height: 300px;" data-script="{{../../../features.social.keys.socialScriptSource}}" data-script-type="{{../../../features.social.keys.socialScriptType}}"></iframe>
+                                    src="{{../../../../features.social.keys.socialAppUrl}}?target={{../../../../rxt.shortName}}:{{../../../id}}&user={{../../../../cuser.username}}&urlDomain={{../../../../features.social.keys.urlDomain}}"
+                                    width="100%" height="100%" style="height: 300px;" data-script="{{../../../../features.social.keys.socialScriptSource}}" data-script-type="{{../../../../features.social.keys.socialScriptType}}"></iframe>
                              {{/if}}
-                            {{#if ../../inDashboard}}
+                            {{#if ../../../inDashboard}}
                                  <div id="comment-content" class="content"></div>
                             {{else}}
                                 <div id="comment-content" class="content user-review"></div>
                             {{/if}}
                         </div>
+                        {{/hasAssetPermission}}
                     </div>
 
                 </div>

--- a/apps/store/themes/store/partials/assets.hbs
+++ b/apps/store/themes/store/partials/assets.hbs
@@ -41,12 +41,14 @@
                             <div class="dropdown dropdown-asset-custom">
                                 <a aria-expanded="false" role="button" data-toggle="dropdown" class="dropdown-toggle more-list" href="javascript:void(0)"></a>
                                 <ul role="menu" class="dropdown-menu">
+                                    {{#hasAssetPermission . key="ASSET_BOOKMARK" type=../../../rxt.shortName username=../../../cuser.username tenantId=../../../cuser.tenantId}}
                                     <li>
                                         {{#mergeContext ssoParam=../../../sso userParam=../../../user thisAsset=../this}}
                                         {{>assets-utilization .}}
                                         {{/mergeContext}}
 
                                     </li>
+                                    {{/hasAssetPermission}}
                                     <li><a href="#">Download</a></li>
                                     <li><a href="#">More Details</a></li>
                                 </ul>

--- a/apps/store/themes/store/partials/navigation.hbs
+++ b/apps/store/themes/store/partials/navigation.hbs
@@ -53,7 +53,9 @@
                       <img src="/store/themes/store/img/icons/store-.png"></a>
             <ul class="dropdown-menu dropdown-account" role="menu" aria-labelledby="dLabel">
                 <li class="uppercase"> <a href="{{url "/pages/my-items"}}">My Subscription</a></li>
+                {{#hasAppPermission . key="APP_MYITEMS" username=cuser.username tenantId=cuser.tenantId}}
                 <li class="uppercase"> <a href="{{url "/pages/my-items"}}">My bookmarks</a> </li>
+                {{/hasAppPermission}}
             </ul>
         </div>
     </div>

--- a/apps/store/themes/store/partials/top_assets.hbs
+++ b/apps/store/themes/store/partials/top_assets.hbs
@@ -42,10 +42,12 @@
                                         <div class="dropdown dropdown-asset-custom">
                                             <a aria-expanded="false" role="button" data-toggle="dropdown" class="dropdown-toggle more-list" href="javascript:return 0;"></a>
                                             <ul role="menu" class="dropdown-menu">
+                                            {{#hasAssetPermission . key="ASSET_BOOKMARK" type=../../rxt.shortName username=../../../../cuser.username tenantId=../../../../cuser.tenantId}}
                                                 <li>
                                                     {{>top-assets-utilization ..}}
                                                 </li>
-                                                <li><a href="{{tenantedUrl "/asts"}}/{{../type}}/details/{{../id}}">More Details</a></li>
+                                            {{/hasAssetPermission}}
+                                                 <li><a href="{{tenantedUrl "/asts"}}/{{../type}}/details/{{../id}}">More Details</a></li>
                                             </ul>
                                         </div>
                                     </div>
@@ -60,3 +62,7 @@
         {{/if}}
     </div>
 {{/each}}
+
+{{#hasAssetPermission . key="ASSET_BOOKMARK" type="gadget" username=cuser.username tenantId=cuser.tenantId}}
+    Bookmarks visible
+{{/hasAssetPermission}}

--- a/apps/store/themes/store/theme.js
+++ b/apps/store/themes/store/theme.js
@@ -209,9 +209,9 @@ var engine = caramel.engine('handlebars', (function() {
                 var key = options.hash.key;
                 var type = options.hash.type;
                 var tenantId = options.hash.tenantId;
-                var username = options.hash.username || 'anon';
+                var username = options.hash.username||rxtAPI.permissions.wso2AnonUsername();
                 var isAuthorized =options.hash.auth ? options.hash.auth : false; 
-                var missingParams = (!key) || (!type) || (!tenantId) || (!username);
+                var missingParams = (!key) || (!type) || (!tenantId)||(!username);
                 //If the user is forcing the view to render 
                 if(isAuthorized){
                     return options.fn(context);
@@ -233,9 +233,9 @@ var engine = caramel.engine('handlebars', (function() {
                 var key = options.hash.key;
                 var type = options.hash.type;
                 var tenantId = options.hash.tenantId;
-                var username = options.hash.username ||'anon';
+                var username = options.hash.username||rxtAPI.permissions.wso2AnonUsername();
                 var isAuthorized =options.hash.auth ? options.hash.auth : false; 
-                var missingParams = (!key) || (!tenantId) || (!username);
+                var missingParams = (!key) || (!tenantId)||(!username);
                 //If the user is forcing the view to render 
                 if(isAuthorized){
                     return options.fn(context);

--- a/jaggery-modules/rxt/module/scripts/permissions/permissions.js
+++ b/jaggery-modules/rxt/module/scripts/permissions/permissions.js
@@ -21,12 +21,12 @@ var permissions = {};
     var log = new Log('rxt-permissions');
     var DEFAULT_ASSET = '_default';
     var PERMISSION_LOAD_HOOK = 'tenantLoad';
-    permissions.ANON_ROLE = 'system/wso2.anonymous.role';
-    var getAnonRole = function(){
+    permissions.ANON_ROLE = 'es.store.anon.user';
+    var getAnonRole = function(tenantId) {
         return permissions.ANON_ROLE;
     };
-    var permissionTreeRoot = function() {
-        return '/_system/governance/permission';
+    var systemPermissionPath = function(path){
+        return '/_system/governance'+path;
     };
     /**
      * Returns the root of the permission tree for given
@@ -35,9 +35,9 @@ var permissions = {};
      * @return {[type]}         A path in the permission tree alocated for the provided app
      */
     var esPermissionRoot = function(appName) {
-        return permissionTreeRoot() + '/es/apps' + appName;
+        return '/permission/enterprisestore/apps' + appName;
     };
-    var esFeaturePermissionRoot = function(){
+    var esFeaturePermissionRoot = function() {
         return '/features';
     };
     var getPermissionNameFromPath = function(path) {
@@ -174,35 +174,55 @@ var permissions = {};
         //Obtain the system registry for the provided tenant
         var server = require('store').server;
         var systemRegistry = server.systemRegistry(tenantId);
-        var fullPath;
         //Check if the path starts with a / if not add one
         if (path.charAt(0) !== '/') {
             path = '/' + path;
         }
-        fullPath = permissionTreeRoot() + path;
         //Check if the permission already exists
-        if (!systemRegistry.exists(fullPath)) {
+        if (!systemRegistry.exists(path)) {
+            log.info('creating permission path: '+path)
             //Add the permission
-            recursivelyCreatePath(fullPath, systemRegistry);
+            //recursivelyCreatePath(fullPath, systemRegistry);
+            return true;
         }
+        log.warn('permision path ' + path + ' not created as it already exists');
+        return false;
     };
-    var addPermissionsToRole = function(permissionMap,role,tenantId){
+    var addPermissionsToRole = function(permissionMap, role, tenantId) {
         var server = require('store').server;
         var um = server.userManager(tenantId);
         var permission;
         var action = 'ui.execute';
-        for(var key in permissionMap){
-            if(permissionMap.hasOwnProperty(key)){
+        for (var key in permissionMap) {
+            if (permissionMap.hasOwnProperty(key)) {
                 permission = permissionMap[key];
-                if(typeof permission === 'string'){
-                    try{
-                        um.authorizeRole(role,permission,action);
-                    } catch(e) {
-                        log.error('Unable to assign permission '+permission+' to role '+role);
+                if (typeof permission === 'string') {
+                    try {
+                        um.authorizeRole(role, permission, action);
+                    } catch (e) {
+                        log.error('Unable to assign permission ' + permission + ' to role ' + role);
                     }
                 }
             }
         }
+    };
+    var addRole = function(role, tenantId) {
+        var server = require('store').server;
+        var um = server.userManager(tenantId);
+        var users = [];
+        var permissions = [];
+        if (!um.roleExists(role)) {
+            log.info('Creating new role: ' + role);
+            try {
+                um.addRole(role,users,permissions);
+                return true;
+            } catch (e) {
+                log.error('role: '+role+' was not created',e);
+                return false;
+            }
+        }
+        log.warn('role ' + role + ' was not created as it already exists');
+        return true;
     };
     /**
      * Creates a permission string which defines an asset level feature
@@ -210,34 +230,46 @@ var permissions = {};
      * @param  {[type]} type       [description]
      * @return {[type]}            [description]
      */
-    var assetFeaturePermissionString = function(permission,type){
+    var assetFeaturePermissionString = function(permission, type) {
         //Get the base app
         var appName = app.getContext();
         var root = esPermissionRoot(appName);
         var featureRoot;
-        if(!type){
+        if (!type) {
             throw 'Unable to create an asset feature permission string without the type';
         }
-        featureRoot = root + esFeaturePermissionRoot()+'/assets/'+type;
-        if(permission.charAt(0) !== '/'){
-            permission = '/'+permission;
+        featureRoot = root + esFeaturePermissionRoot() + '/assets/' + type;
+        if (permission.charAt(0) !== '/') {
+            permission = '/' + permission;
         }
-        return featureRoot+permission;
+        return featureRoot + permission;
     };
-    var appFeaturePermissionString  = function(permission){
+    var appFeaturePermissionString = function(permission) {
         //Get the base app
         var appName = app.getContext();
         var root = esPermissionRoot(appName);
         var featureRoot;
-        if(!type){
+        if (!type) {
             throw 'Unable to create an asset feature permission string without the type';
         }
-        featureRoot = root + esFeaturePermissionRoot()+'/app';
-        if(permission.charAt(0) !== '/'){
-            permission = '/'+permission;
+        featureRoot = root + esFeaturePermissionRoot() + '/app';
+        if (permission.charAt(0) !== '/') {
+            permission = '/' + permission;
         }
-        return featureRoot+permission;
+        return featureRoot + permission;
     };
+    var assetFeaturePermissionKey = function(feature,type){
+        if((!feature) || (!type)){
+            throw 'Unable to generate asset feature permission key without a feature name and a type';
+        }
+        return 'ASSET_'+type.toUpperCase()+'_'+feature.toUpperCase();
+    };
+    var appFeaturePermissionKey = function(feature){
+        if(!feature){
+            throw 'Unable to generate app feature permission key without a feature name';
+        }
+        return 'APP_'+feature.toUpperCase();
+    }
     permissions.init = function() {
         var event = require('event');
         event.on('tenantLoad', function(tenantId) {
@@ -284,7 +316,6 @@ var permissions = {};
     permissions.ASSET_BOOKMARK = 'ASSET_BOOKMARK';
     permissions.APP_STATISTICS = 'APP_STATISTICS';
     permissions.APP_MYITEMS = 'APP_MYITEMS';
-
     var buildEmptyPermissionMap = function() {
         var map = {};
         // for (var index = 0; index < permissionKeySet.length; index++) {
@@ -313,6 +344,10 @@ var permissions = {};
         context.utils.assetFeaturePermissionString = assetFeaturePermissionString;
         context.utils.appFeaturePermissionString = appFeaturePermissionString;
         context.utils.addPermissionsToRole = addPermissionsToRole;
+        context.utils.addRole = addRole;
+        context.utils.assetFeaturePermissionKey = assetFeaturePermissionKey;
+        context.utils.appFeaturePermissionKey = appFeaturePermissionKey;
+        context.utils.anonRole = getAnonRole;
         for (var key in options) {
             if (options.hasOwnProperty(key)) {
                 context[key] = options[key];
@@ -344,12 +379,17 @@ var permissions = {};
     };
     var registerPermissions = function(map, tenantId) {
         var permission;
+        var modifiedPath;
         for (var key in map) {
             if (map.hasOwnProperty(key)) {
                 permission = map[key];
                 if (typeof permission === 'string') {
-                    log.info('Registering permission ' + permission);
-                    //addPermission(permission, tenantId);
+                    if(permission.charAt(0)!=='/'){
+                        permission = '/'+permission;
+                    }
+                    permission = systemPermissionPath(permission);
+                    //log.info('Registering permission ' + permission);
+                    addPermission(permission, tenantId);
                 }
             }
         }
@@ -483,9 +523,9 @@ var permissions = {};
     var checkPermissionString = function(username, permission, action, authorizer) {
         var isAuthorized = false;
         try {
-            if(!username){
-                log.warn('username not provided to check '+permission+'.The anon role will be used to check permissions');
-                isAuthorized = authorizer.isRoleAuthorized(getAnonRole(),permission,action);
+            if (!username) {
+                log.warn('username not provided to check ' + permission + '.The anon role will be used to check permissions');
+                isAuthorized = authorizer.isRoleAuthorized(getAnonRole(), permission, action);
             } else {
                 isAuthorized = authorizer.isUserAuthorized(username, permission, action);
             }
@@ -524,7 +564,7 @@ var permissions = {};
             return isAuthorized;
         }
         options.username = username;
-        context = buildPermissionContext(tenantId,options);
+        context = buildPermissionContext(tenantId, options);
         //context.userManager = userManager;
         try {
             result = permission(context) || true;
@@ -542,7 +582,7 @@ var permissions = {};
         }
         return isAuthorized;
     };
-    var checkAssetPermission = function(key, type, tenantId, username,options) {
+    var checkAssetPermission = function(key, type, tenantId, username, options) {
         var permission;
         options = options || {};
         permission = mapToAssetPermission(key, type, tenantId);
@@ -551,9 +591,9 @@ var permissions = {};
             return false;
         }
         options.username = username;
-        return isPermissable(permission, tenantId, username,options);
+        return isPermissable(permission, tenantId, username, options);
     };
-    var checkAppPermission = function(key, tenantId, username,options) {
+    var checkAppPermission = function(key, tenantId, username, options) {
         var permission;
         options = options || {};
         permission = mapToAppPermission(key, tenantId);
@@ -562,7 +602,7 @@ var permissions = {};
             return false;
         }
         options.username = username;
-        return isPermissable(permission, tenantId, username,options);
+        return isPermissable(permission, tenantId, username, options);
     };
     permissions.hasAssetPermission = function() {
         var key = arguments[0];
@@ -586,9 +626,9 @@ var permissions = {};
         if ((!username) || (!tenantId)) {
             throw 'Unable to resolve permissions without the tenantId and username';
         }
-        log.info('Checking permission '+key+' for ' + username + ' tenantId ' + tenantId+' type '+type);
-        authorized = checkAssetPermission(key, type, tenantId, username,options);
-        log.info('Authorized :'+authorized);
+        log.info('Checking permission ' + key + ' for ' + username + ' tenantId ' + tenantId + ' type ' + type);
+        authorized = checkAssetPermission(key, type, tenantId, username, options);
+        log.info('Authorized :' + authorized);
         return authorized;
     };
     permissions.hasAppPermission = function() {
@@ -610,9 +650,9 @@ var permissions = {};
         if ((!username) || (!tenantId)) {
             throw 'Unable to resolve permissios without the tenantId and username';
         }
-        log.info('Checking permissions'+key+' for ' + username + ' tenantId ' + tenantId);
+        log.info('Checking permissions' + key + ' for ' + username + ' tenantId ' + tenantId);
         authorized = checkAppPermission(key, tenantId, username);
-        log.info('Authorized: '+authorized);
+        log.info('Authorized: ' + authorized);
         return authorized;
     };
     var locateEndpointDetails = function(endpoints, url) {
@@ -660,7 +700,7 @@ var permissions = {};
             log.error('Unable to locate a mapping for permission ' + key);
             return true;
         }
-        return isPermissable(permission, tenantId, username,options);
+        return isPermissable(permission, tenantId, username, options);
     };
     permissions.hasAssetAPIPermission = function(type, apiURL, tenantId, username) {
         var details = assetAPIEndpoint(type, tenantId, apiURL);
@@ -689,7 +729,7 @@ var permissions = {};
             log.error('Unable to locate a mapping for permission ' + key);
             return true;
         }
-        return isPermissable(permission, tenantId, username,options);
+        return isPermissable(permission, tenantId, username, options);
     };
     permissions.hasAppPagePermission = function(pageURL, tenantId, username) {
         var details = app.getPageEndpoint(tenantId, pageURL);
@@ -746,4 +786,5 @@ var permissions = {};
         }
         return isPermissable(permission, tenantId, username);
     };
+    permissions.getAnonRole = getAnonRole;
 }(core, asset, app, permissions));

--- a/jaggery-modules/rxt/module/scripts/permissions/permissions.js
+++ b/jaggery-modules/rxt/module/scripts/permissions/permissions.js
@@ -531,6 +531,7 @@ var permissions = {};
                 log.warn('username not provided to check ' + permission + '.The anon role will be used to check permissions');
                 isAuthorized = authorizer.isRoleAuthorized(getAnonRole(), permission, action);
             } else {
+                log.info('using username: '+username+' to check permission');
                 isAuthorized = authorizer.isUserAuthorized(username, permission, action);
             }
         } catch (e) {
@@ -791,4 +792,5 @@ var permissions = {};
         return isPermissable(permission, tenantId, username);
     };
     permissions.getAnonRole = getAnonRole;
+    permissions.wso2AnonUsername = wso2AnonUsername;
 }(core, asset, app, permissions));

--- a/jaggery-modules/rxt/module/scripts/permissions/permissions.js
+++ b/jaggery-modules/rxt/module/scripts/permissions/permissions.js
@@ -182,10 +182,10 @@ var permissions = {};
         if (!systemRegistry.exists(path)) {
             log.info('creating permission path: '+path)
             //Add the permission
-            //recursivelyCreatePath(fullPath, systemRegistry);
+            recursivelyCreatePath(path, systemRegistry);
             return true;
         }
-        log.warn('permision path ' + path + ' not created as it already exists');
+        log.debug('permision path ' + path + ' not created as it already exists');
         return false;
     };
     var addPermissionsToRole = function(permissionMap, role, tenantId) {
@@ -340,7 +340,8 @@ var permissions = {};
         }
         context = core.createSystemContext(tenantId);
         context.utils = {};
-        context.utils.addPermission = addPermission;
+        //context.utils.addPermission = addPermission;
+        context.utils.registerPermissions = registerPermissions;//TODO: fix to accept just permission and not tenantid
         context.utils.assetFeaturePermissionString = assetFeaturePermissionString;
         context.utils.appFeaturePermissionString = appFeaturePermissionString;
         context.utils.addPermissionsToRole = addPermissionsToRole;

--- a/jaggery-modules/rxt/module/scripts/permissions/permissions.js
+++ b/jaggery-modules/rxt/module/scripts/permissions/permissions.js
@@ -252,8 +252,8 @@ var permissions = {};
         var appName = app.getContext();
         var root = esPermissionRoot(appName);
         var featureRoot;
-        if (!type) {
-            throw 'Unable to create an asset feature permission string without the type';
+        if (!permission) {
+            throw 'Unable to create an asset feature permission string without the permission';
         }
         featureRoot = root + esFeaturePermissionRoot() + '/app';
         if (permission.charAt(0) !== '/') {

--- a/jaggery-modules/rxt/module/scripts/permissions/permissions.js
+++ b/jaggery-modules/rxt/module/scripts/permissions/permissions.js
@@ -25,6 +25,9 @@ var permissions = {};
     var getAnonRole = function(tenantId) {
         return permissions.ANON_ROLE;
     };
+    var wso2AnonUsername = function(){
+        return 'wso2.anonymous.user';
+    };
     var systemPermissionPath = function(path){
         return '/_system/governance'+path;
     };
@@ -524,7 +527,7 @@ var permissions = {};
     var checkPermissionString = function(username, permission, action, authorizer) {
         var isAuthorized = false;
         try {
-            if (!username) {
+            if ((!username) || (username === wso2AnonUsername()) ) {
                 log.warn('username not provided to check ' + permission + '.The anon role will be used to check permissions');
                 isAuthorized = authorizer.isRoleAuthorized(getAnonRole(), permission, action);
             } else {


### PR DESCRIPTION
This PR adds a number of fixes and additions to the Permission model.

## Changes 
- A new role: es.store.anon.user role has been added to control anonymous access to the Store
- The wso2.anonymous user permissions are resolved using the es.store.anon.user role
- The following views in the Store are now controlled by permissions
  - Asset listing (Access to the asset listing page and the presence of the asset type in the asset type browser) (ASSET_LIST)
 - Asset details  (ASSET_DETAILS mapped to ASSET_LIST)
 - Bookmarking button (ASSET_BOOKMARK)
 - User reviews  (ASSET_REVIEWS)
 - My Items view (APP_MYITEMS)
- The following views in the Publisher are now controlled by permissions:
 - Asset edit view (ASSET_UPDATE)

## Features
- Permissions assigned to the permissions object (available in the permission.js:tenantLoad method)  are automatically created
- Addition of asset and app features for each application (Store and Publisher)
 - Store:
    - app/feature/myitems (APP_MYITEMS)
    - asset/{type}/feature/bookmark (ASSET_BOOKMARK)
    - asset/{type}/feature/list  (ASSET_LIST)
    - asset/{type}/feature/reviews (ASSET_REVIEWS)
 - Publisher:
   - asset/{type}/feature/update (ASSET_UPDATE)

## Fixed
- Fixed an issue with the hasAssetPermission and hasAppPermission helpers resolving a null username to the anon user
