### PR TITLE
Grouping fixes to the search API

### DIFF
--- a/apps/publisher/modules/asset-api.js
+++ b/apps/publisher/modules/asset-api.js
@@ -459,17 +459,24 @@ var result;
         paging.start = (request.getParameter("start") || paging.start);
         paging.paginationLimit = (request.getParameter("paginationLimit") || paging.paginationLimit);
         var q = (request.getParameter("q") || '');
+        var isGroupingEnabled = false;//Grouping is disabled by default
         try {
             var assets;
             if (q) { //if search-query parameters are provided
                 var qString = '{' + q + '}';
                 var query = validateQuery(qString);
                 query = replaceCategoryQuery(query, rxtManager, options.type);
+                isGroupingEnabled = rxtManager.isGroupingEnabled(options.type);
+                if(isGroupingEnabled){
+                    query._group = true; //Signal grouping is enabled
+                    query.default = true; //Required for grouping query
+                }
                 //query = replaceNameQuery(query, rxtManager, options.type);
                 if (log.isDebugEnabled) {
                     //Need to log this as we perform some processing on the name and
                     //category values
                     log.debug('processed query used for searching: ' + stringify(query));
+                    log.debug('grouping enabled: '+isGroupingEnabled);
                 }
                 assets = assetManager.advanceSearch(query, paging); // asset manager back-end call with search-query
             } else {
@@ -528,6 +535,8 @@ var result;
                     //category values
                     log.debug('processed query used for searching: ' + stringify(query));
                 }
+                //TODO: The generic advance search does not honour grouping
+                //as grouping can be enabled/disabled per asset type
                 assets = assetAPI.advanceSearch(query, paging,session); // asset manager back-end call with search-query
             } else {
                 log.error('Unable to perform a bulk asset retrieval without a type been specified');

--- a/apps/publisher/themes/default/js/list_assets.js
+++ b/apps/publisher/themes/default/js/list_assets.js
@@ -220,9 +220,9 @@ var parseUsedDefinedQuery = function(input) {
     for(var index = 0; index < terms.length; index++){
         term = terms[index];
         term = term.trim(); //Remove any whitespaces
-        //If this term is empty and does not have a : then it should be appended to the
+        //If this term is not empty and does not have a : then it should be appended to the
         //previous term
-        if((term.length>0)&&(isTokenizedTerm(term))){
+        if((!isEmpty(term))&&(!isTokenizedTerm(term))){
             previous = arr.length -1;
             if(previous>=0) {
                 arr[previous]= arr[previous]+' '+term;

--- a/apps/store/modules/asset-api.js
+++ b/apps/store/modules/asset-api.js
@@ -267,6 +267,7 @@ var responseProcessor = require('utils').response;
         });
         var rxtModule = require('rxt');
         var rxtManager = rxtModule.core.rxtManager(tenantId);
+        var isGroupingEnabled = false; //Assume that grouping is disabled
         if (!userDetails) {
             assetManager = asset.createAnonAssetManager(session, options.type, tenantId);
         } else {
@@ -303,6 +304,11 @@ var responseProcessor = require('utils').response;
                 var qString = '{' + q + '}';
                 var query = validateQuery(qString);
                 query = replaceCategoryQuery(query, rxtManager, options.type);
+                isGroupingEnabled  = rxtManager.isGroupingEnabled(options.type);
+                if(isGroupingEnabled){
+                    query._group = true;
+                    query.default = true;
+                }
                 //query = replaceNameQuery(query, rxtManager, options.type);
                 var assets = assetManager.advanceSearch(query, paging); //doesnt work properly
             } else {
@@ -382,7 +388,8 @@ var responseProcessor = require('utils').response;
                     //category values
                     log.debug('processed query used for searching: ' + stringify(query));
                 }
-                //Obtain the correct tenant Id to support /t/ urls
+                //Note: Advance generic searches will not support grouping as it can 
+                //be enabled/disabled per asset type
                 var assets = asset.advanceSearch(query,paging,session,tenantId); 
             } else {
                 log.error('Unable to perform a bulk asset retrieval without a type been specified');

--- a/jaggery-modules/rxt/module/scripts/asset/asset.js
+++ b/jaggery-modules/rxt/module/scripts/asset/asset.js
@@ -417,8 +417,7 @@ var asset = {};
         var queryString = [];
         var value;  
         options = options || {};
-        var wildcard = options.wildcard||true; //Default to a wildcard search
-
+        var wildcard = options.hasOwnProperty('wildcard')? options.wildcard : true; //Default to a wildcard search
         for(var key in query) {
             //Drop the type property from the query
             if((query.hasOwnProperty(key)) && (key!='type')){
@@ -546,10 +545,10 @@ var asset = {};
     var buildQuery = function(query){
         var q = '';
         var options = {};
-        options.wildcard = false;
+        options.wildcard = true; //Assume that wildcard is enabled
         //Check if grouping is enabled
          if ((query.hasOwnProperty(constants.Q_PROP_GROUP)) && (query[constants.Q_PROP_GROUP] === true)) {
-            options.wildcard = query[constants.Q_PROP_GROUP];
+            options.wildcard = false;//query[constants.Q_PROP_GROUP];
             delete query[constants.Q_PROP_GROUP];
          } 
          q  = buildQueryString(query, options);


### PR DESCRIPTION
This PR fixes an issue with the search API (both in the Store and Publisher) not grouping assets when the grouping feature is enabled.