### PR TITLE
REGISTRY-2814 Fix - Remove spinner and wait message when duplicate soap services are added…

### DIFF
--- a/apps/publisher/themes/default/js/create_asset.js
+++ b/apps/publisher/themes/default/js/create_asset.js
@@ -49,6 +49,7 @@ $(function(){
         error:function(){
             messages.alertError('Unable to add the '+PublisherUtils.resolveCurrentPageAssetType()+' instance.');
             $('#btn-create-asset').removeAttr('disabled');
+            $('.fa-spinner').parent().remove();
 
         }
     });


### PR DESCRIPTION
When duplicate soap service or rest service is added, "Please wait" message shows continuously with spinner. This fix removes  the message after error notification is displayed.