### PR TITLE
fixing character encoding for advanced search results

### DIFF
--- a/apps/publisher/modules/asset-api.js
+++ b/apps/publisher/modules/asset-api.js
@@ -636,6 +636,7 @@ var result;
                 log.debug("Error while searching assets as for the request : " + req.getQueryString());
             }
         }
+        response.characterEncoding = 'ISO-8859-1';
         return result;
     };
     var replaceCategoryQuery = function (q, rxtManager, type) {

--- a/apps/store/modules/asset-api.js
+++ b/apps/store/modules/asset-api.js
@@ -413,6 +413,7 @@ var responseProcessor = require('utils').response;
             log.error(e);
         }
         ratingApi.addRatings(result);
+        response.characterEncoding = 'ISO-8859-1';
         return result;  
     };
     var replaceCategoryQuery = function(q, rxtManager, type) {

--- a/jaggery-modules/rxt/module/scripts/asset/asset.js
+++ b/jaggery-modules/rxt/module/scripts/asset/asset.js
@@ -1063,6 +1063,7 @@ var asset = {};
         } catch(e){
             log.error('Unable to retrieve the tags of the provided asset ',e);
         }
+	response.characterEncoding = 'ISO-8859-1';
         return tags;
     };
     /**


### PR DESCRIPTION
This issue was solved by adding character-encoding from the server side before sending out the response.
Please refer to [3].

[1] https://wso2.org/jira/browse/STORE-1108
[2] https://wso2.org/jira/browse/REGISTRY-2968
[3] http://stackoverflow.com/questions/3198532/jquery-ajax-call-messes-up-character-encoding