### PR TITLE
Fixing STORE-1112: 500 error when trying to access secured extension APIs without logged in

### DIFF
--- a/apps/publisher/controllers/apis-router.jag
+++ b/apps/publisher/controllers/apis-router.jag
@@ -52,13 +52,18 @@ if (uriMatcher.match(API_URL)) {
             request.getMappedPath = mapper(path);
             var username = user ? user.username : null;
             var isAuthorized = rxtAPI.permissions.hasAppAPIPermission(page,tenantId,username);
-            if(!isAuthorized){
-                log.error('user '+username+' does not have permission to access the api '+page);
-                response.sendError(401,'You do not have access to this api');
-            } else {          
-                var proceed = app.execApiHandlers('onApiLoad', request, response, session, page);
-                if (proceed) {
-                    include(path);
+            if(!username){
+                log.error('user need to authenticate before access the api ' + page);
+                response.sendError(401,'You do not have access to this page');
+            }else {
+                if(!isAuthorized){
+                    log.error('user '+username+' does not have permission to access the api '+page);
+                    response.sendError(401,'You do not have access to this api');
+                } else {          
+                    var proceed = app.execApiHandlers('onApiLoad', request, response, session, page);
+                    if (proceed) {
+                        include(path);
+                    }
                 }
             }
         } else {

--- a/apps/store/controllers/apis-router.jag
+++ b/apps/store/controllers/apis-router.jag
@@ -50,13 +50,18 @@ if (uriMatcher.match(API_URL)) {
             request.getMappedPath = mapper(path);
             var username = user ? user.username : null;
             var isAuthorized = rxtAPI.permissions.hasAppAPIPermission(page, tenantId, username);
-            if (!isAuthorized) {
-                log.error('user ' + username + ' does not have permission to access the api ' + page);
+            if(!username){
+                log.error('user need to authenticate before access the api ' + page);
                 response.sendError(401,'You do not have access to this page');
             } else {
-                var proceed = app.execApiHandlers('onApiLoad', request, response, session, page);
-                if (proceed) {
-                    include(path);
+                if (!isAuthorized) {
+                    log.error('user ' + username + ' does not have permission to access the api ' + page);
+                    response.sendError(403,'You do not have access to this page');
+                } else {
+                    var proceed = app.execApiHandlers('onApiLoad', request, response, session, page);
+                    if (proceed) {
+                        include(path);
+                    }
                 }
             }
         } else {

--- a/apps/store/controllers/apis-router.jag
+++ b/apps/store/controllers/apis-router.jag
@@ -56,7 +56,7 @@ if (uriMatcher.match(API_URL)) {
             } else {
                 if (!isAuthorized) {
                     log.error('user ' + username + ' does not have permission to access the api ' + page);
-                    response.sendError(403,'You do not have access to this page');
+                    response.sendError(401,'You do not have access to this page');
                 } else {
                     var proceed = app.execApiHandlers('onApiLoad', request, response, session, page);
                     if (proceed) {

--- a/jaggery-modules/rxt/module/scripts/permissions/permissions.js
+++ b/jaggery-modules/rxt/module/scripts/permissions/permissions.js
@@ -617,9 +617,6 @@ var permissions = {};
         var isAuthorized = false; //Assume authorization will fail
         var context;
         var result;
-        if (!username) {
-            throw 'Unable to resolve permissions without a username';
-        }
         if (!tenantId) {
             throw 'Unable to resolve permissions without a tenantId';
         }

--- a/jaggery-modules/rxt/module/scripts/permissions/permissions.js
+++ b/jaggery-modules/rxt/module/scripts/permissions/permissions.js
@@ -617,6 +617,9 @@ var permissions = {};
         var isAuthorized = false; //Assume authorization will fail
         var context;
         var result;
+        if (!username) {
+            throw 'Unable to resolve permissions without a username';
+        }
         if (!tenantId) {
             throw 'Unable to resolve permissions without a tenantId';
         }


### PR DESCRIPTION
When user accesses specified apis without logged in, store/publisher api-router fails with a 500 error. Therefore, username null check is handled.

This fixes https://wso2.org/jira/browse/STORE-1112.
