### PR TITLE
Fixes for STORE-1139 and STORE-1156 

### DIFF
--- a/apps/store/config/store-tenant.json
+++ b/apps/store/config/store-tenant.json
@@ -8,7 +8,7 @@
             "keys": {
                 "socialScriptSource": "%https.host%/social/export-js/social.js",
                 "socialScriptType": "text/javascript",
-                "socialAppUrl": "https://localhost:9443/social"
+                "socialAppUrl": "%https.local%/social"
             }
         },
         "assetTypesHotDelploy": {

--- a/apps/store/modules/page-decorators.js
+++ b/apps/store/modules/page-decorators.js
@@ -335,6 +335,7 @@ var pageDecorators = {};
     pageDecorators.socialFeature = function(ctx, page) {
         var app = require('rxt').app;
         var constants = require('rxt').constants;
+        var utils = require('utils');
         if (!app.isFeatureEnabled(ctx.tenantId, constants.SOCIAL_FEATURE)) {
             log.debug('social feature has been disabled.');
             return page;
@@ -347,6 +348,7 @@ var pageDecorators = {};
             tenantId: ctx.tenantId
         });
         socialFeatureDetails.keys.urlDomain = domain; //getDomainFromURL(request);
+        utils.url.popServerDetails(socialFeatureDetails.keys);
         page.features[constants.SOCIAL_FEATURE] = socialFeatureDetails;
         return page;
     };

--- a/apps/store/themes/store/partials/assets.hbs
+++ b/apps/store/themes/store/partials/assets.hbs
@@ -23,8 +23,11 @@
             {{>assets-thumbnails .}}
         </section>
     {{else}}
-        <div class="clear-both"></div>
-        <div class="top-assets-empty-assert">{{t "We couldn't find anything for you."}}</div>
+        {{#if cuser.isAnon}}
+            <div class="top-assets-empty-assert">{{t "There are no publicly available assets available. Please login to see more"}}</div>
+        {{else}}
+            <div class="top-assets-empty-assert">{{t "There are no assets available."}}</div>
+        {{/if}}
     {{/if}}
 </div>
 

--- a/jaggery-modules/utils/module/scripts/url/url.js
+++ b/jaggery-modules/utils/module/scripts/url/url.js
@@ -38,6 +38,10 @@ var url = {};
                     value=value.replace('%https.carbon.local.ip%', 'https://' + carbonLocalIP + ':' + httpsPort);
                 } else if ((typeof value === 'string') && value.indexOf('%http.carbon.local.ip%') > -1) {
                     value=value.replace('%http.carbon.local.ip%', 'http://' + carbonLocalIP + ':' + httpPort);
+                } else if((typeof value === 'string') && value.indexOf('%http.local') > -1 ){
+                    value=value.replace('%http.local%', 'http://localhost:' + httpPort);
+                } else if((typeof value === 'string') && value.indexOf('%https.local') > -1){
+                    value=value.replace('%https.local%', 'https://localhost:' + httpsPort);
                 }
                 obj[key] = value;
             }


### PR DESCRIPTION
Addresses the following issues
- https://wso2.org/jira/browse/STORE-1156
- https://wso2.org/jira/browse/STORE-1139

### Note 
[STORE-1156](https://wso2.org/jira/browse/STORE-1156)
 - A doc JIRA needs to be created indicating the need to change the socialAppUrl property to the location where the social application is hosted
- The socialAppUrl property is located in the {CARBON_HOME}/repository/deployment/server/jaggeryapps/store/config/store-tenant.json: 
```json
"features": {
        "social": {
            "enabled": true,
            "keys": {
                "socialScriptSource": "%https.host%/social/export-js/social.js",
                "socialScriptType": "text/javascript",
                "socialAppUrl": "%https.local%/social"
            }
        }
```
- In situations where the server has been started atleast once the change needs to be done to /_system/config/store/configs/store.json
- The https.local token will be replaced with localhost at runtime
- This property also supports the following tokens:
   - https.host
   - http.host
   - https.carbon.local.ip