### PR TITLE
Fix for STORE-1089

### DIFF
--- a/apps/publisher/extensions/lifecycles/SampleLifeCycle.xml
+++ b/apps/publisher/extensions/lifecycles/SampleLifeCycle.xml
@@ -76,6 +76,9 @@
                                            value="Internal/publisher:-get,-add,-delete,-authorize"/>
                             </execution>
                         </data>
+                        <data name="transitionPermission">
+                            <permission forEvent="Promote" roles="Internal/reviewer,admin"/>
+                        </data>
                     </datamodel>
                     <transition event="Promote" target="Published"/>
                 </state>

--- a/apps/publisher/modules/lifecycle/lifecycle-api.js
+++ b/apps/publisher/modules/lifecycle/lifecycle-api.js
@@ -282,7 +282,6 @@ var error = '';
                     replaceApprovedActions[approvedLCActions[i]] = true;
                 }
             }
-
             approvedActions = replaceApprovedActions;
         } catch (e) {
             var msg = 'No approved acions are available for this asset state';
@@ -414,9 +413,9 @@ var error = '';
             state.isDeletable = isDeletable(lcState, state.deletableStates, lcName);
         }
         //Update the state of the check items
-        state.isLCActionsPermitted = isLCActionsPermitted(asset, options, req, res, session);
-        state.checkItems = setCurrentCheckItemState(state.checkItems, lcCheckedStates, state.isLCActionsPermitted);
         state.approvedActions = setAvailableApprovedActions(state.approvedActions, lcCheckedStates);
+        state.isLCActionsPermitted = isLCActionsPermitted(state.approvedActions); //(state.approvedActions.length > 0 ) ? true : false;//isLCActionsPermitted(asset, options, req, res, session);
+        state.checkItems = setCurrentCheckItemState(state.checkItems, lcCheckedStates, state.isLCActionsPermitted);
         return state;
     };
     /**
@@ -602,9 +601,15 @@ var error = '';
         });
         return lifecycleComments;
     };
-    var isLCActionsPermitted = function (asset, options, req, res, session) {
-        var permissions = require('/modules/lifecycle/permissions.js').permissions;
-        return permissions.isLCActionsPermitted( asset.path, session);
+    var isLCActionsPermitted = function (actions) {
+        for(var key in actions){
+            if(actions.hasOwnProperty(key)){
+                return true;
+            }
+        }
+        //var permissions = require('/modules/lifecycle/permissions.js').permissions;
+        //return permissions.isLCActionsPermitted( asset.path, session);
+        return false;
     };
     var isLCPermitted = function (asset, session) {
         var permissions = require('/modules/lifecycle/permissions.js').permissions;

--- a/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/generic/GenericExecutor.java
+++ b/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/generic/GenericExecutor.java
@@ -75,8 +75,9 @@ public class GenericExecutor implements Execution
 
         DynamicValueInjector dynamicValueInjector=new DynamicValueInjector();
 
+        String assetAuthor =  requestContext.getResource().getAuthorUserName();
         //Set the asset author key
-        dynamicValueInjector.setDynamicValue(DynamicValueInjector.ASSET_AUTHOR_KEY,requestContext.getResource().getAuthorUserName());
+        dynamicValueInjector.setDynamicValue(DynamicValueInjector.ASSET_AUTHOR_KEY,cleanUsername(assetAuthor));
 
         //Execute all permissions for the current state
         //this.stateExecutor.executePermissions(this.userRealm,dynamicValueInjector,path,s2);
@@ -93,6 +94,9 @@ public class GenericExecutor implements Execution
         return true;
     }
 
+    private String cleanUsername(String username){
+        return username.replace("@","-AT-").replace("/","-AT-");
+    }
     /*
     The method obtains the tenant id from a string tenant id
      */

--- a/jaggery-modules/store/module/scripts/user.js
+++ b/jaggery-modules/store/module/scripts/user.js
@@ -32,7 +32,7 @@ var user = {};
          * "/" will be replaced.
          */
 
-        return username.replace('@', ':').replace('/', ':');
+        return username.replace('@', '-AT-').replace('/', '-AT-');
     };
 
     user.cleanUsername=function(username){


### PR DESCRIPTION
**This PR fixes multiple issues:**
1. Ensures that only users with the Internal/reviewer role are able to move an asset to the Published state when using the SampleLifecycle2
2. Ensures that the SCXML executor shipped with the ES does not create an unclean user role (E.g. Internal/private_mgjaye@gmail.com) when Email log in is enabled.
3. Fixes the cleaned username to use the -AT- replacement instead of : (colon) which conflicts with the way permission data is stored 

**In order to effect the above fixes the following changes have been made:**
1. The SampleLifecycle2 now uses transitionPermission data element to specify roles which are able to perform actions for a given state
2. The check to ensure lifecycle actions can be performed now uses the actions list returned by the Governance API
3. The : (colon) replacement has been changed to -AT-