### PR TITLE
Made asset update API atomic

### DIFF
--- a/apps/publisher/test/Assets_spec.js
+++ b/apps/publisher/test/Assets_spec.js
@@ -146,12 +146,21 @@ describe('Assets POST - Publisher API', function () {
      * test: check for a return-asset
      */
     it('Test update assets by id', function () {
+        var log = new Log();
         assetID = getAssetID();
         var url = server_url + '/assets/' + assetId + '?type=gadget';
         url = encodeURI(url);
         var header = obtainAuthorizedHeaderForAPICall();
-        var asset = {   'overview_description': 'Test rest api testing update',
-            'overview_category': 'Template'};
+
+        //First try to obtain the asset
+        var original = get(url,{},header,'json');
+        log.info('original asset ');
+        log.info(original);
+        var asset = original.data.attributes;
+        asset.overview_description = 'Test rest api testing update';
+        asset.overview_category = 'Template';
+        /*var asset = {   'overview_description': '',
+            'overview_category': 'Template'};*/
         try {
             var response = post(url, asset, header, 'json');
         } catch (e) {

--- a/apps/publisher/test/Assets_spec.js
+++ b/apps/publisher/test/Assets_spec.js
@@ -154,8 +154,6 @@ describe('Assets POST - Publisher API', function () {
 
         //First try to obtain the asset
         var original = get(url,{},header,'json');
-        log.info('original asset ');
-        log.info(original);
         var asset = original.data.attributes;
         asset.overview_description = 'Test rest api testing update';
         asset.overview_category = 'Template';


### PR DESCRIPTION
When calling the asset update REST API the invokee must provide the complete asset representation.