### PR TITLE
Fixed tag UI not appearing

### DIFF
--- a/apps/publisher/themes/default/partials/create_form.hbs
+++ b/apps/publisher/themes/default/partials/create_form.hbs
@@ -16,11 +16,11 @@
     {{/if}}
     <div id='tag-ui-container'>
         <h2 class="field-title">
-            <a data-toggle="collapse" href="#collapseTags" aria-expanded="false" class="collapsing-h2" >
+            <a href="#collapseTags" aria-expanded="false" class="collapsing-h2" >
                 <i class="cu-btn-exp-col btn-collapsed">{{t "Tags"}}</i>
             </a>
         </h2>
-        <div id="collapseTags" class="collapse in responsive-form-container">
+        <div id="collapseTags">
             {{> tag-ui-container .}}
         </div>
     </div>

--- a/apps/publisher/themes/default/partials/update_form.hbs
+++ b/apps/publisher/themes/default/partials/update_form.hbs
@@ -24,11 +24,11 @@
     {{/if}}
      <div id='tag-ui-container'>
          <h2 class="field-title">
-             <a data-toggle="collapse" href="#collapseTags" aria-expanded="false" class="collapsing-h2" >
+             <a href="#collapseTags" aria-expanded="false" class="collapsing-h2" >
                  <i class="cu-btn-exp-col btn-collapsed">{{t "Tags"}}</i>
              </a>
          </h2>
-         <div id="collapseTags" class="collapse in responsive-form-container">
+         <div id="collapseTags">
              {{> tag-ui-container .}}
          </div>
      </div>


### PR DESCRIPTION
**Note**: This fix was provided by Chanka Jayasena

The fix removes data-toggle functionality provided by Bootstrap and uses the custom toggle logic.

The fix also removes a CSS class which does not exist.
