### PR TITLE
Fix for REGISTRY-3201 - Lifecycle view in G-Reg publisher is not working google chrome browser

### DIFF
--- a/apps/publisher/themes/default/helpers/lifecycle-base.js
+++ b/apps/publisher/themes/default/helpers/lifecycle-base.js
@@ -20,7 +20,7 @@ var resources = function (page, meta) {
     return {
     	css:['lifecycle-styles.css'],
     	code:['publisher.lifecycle.meta.hbs'],
-        js: ['libs/d3.min.js','lifecycle/lodash.min.js','lifecycle/graphlib.core.min.js','lifecycle/dagre-d3.min.js','lifecycle/lifecycle-core.js','lifecycle/lifecycle-configs.js','lifecycle/lifecycle-init.js']
+        js: ['chrome.lifecycle.fix.js','libs/d3.min.js','lifecycle/lodash.min.js','lifecycle/graphlib.core.min.js','lifecycle/dagre-d3.min.js','lifecycle/lifecycle-core.js','lifecycle/lifecycle-configs.js','lifecycle/lifecycle-init.js']
     };
 };
 //'libs/d3.min.js',

--- a/apps/publisher/themes/default/js/chrome.lifecycle.fix.js
+++ b/apps/publisher/themes/default/js/chrome.lifecycle.fix.js
@@ -1,0 +1,4 @@
+SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformToElement || function(elem) {
+    return elem.getScreenCTM().inverse().multiply(this.getScreenCTM());
+};
+//https://github.com/cpettitt/dagre-d3/issues/202


### PR DESCRIPTION
lifecycle view is not rendered only in google chrome version and this happens due to  chrome (48.0.2564.23) removes SVGElement.prototype.getTransformToElement which is used by D3.

D3 Issue: https://github.com/cpettitt/dagre-d3/issues/202