### PR TITLE
STORE-1182 Refactoring query string formatter logic

### DIFF
--- a/apps/publisher/extensions/assets/default/pages/list.jag
+++ b/apps/publisher/extensions/assets/default/pages/list.jag
@@ -16,6 +16,7 @@
  */
 var caramel;
 var constant = require("rxt").constants;
+var utilsRequest = require('utils').request;
 var PAGING = constant.DEFAULT_ASSET_PAGIN;
 require('/modules/publisher.js').exec(function(ctx) {
     caramel = require('caramel');
@@ -40,5 +41,8 @@ require('/modules/publisher.js').exec(function(ctx) {
     //Do an advanced search
     assets  = assetApi.advanceSearch(options,ctx.request,ctx.response,ctx.session)||[];
     var output = am.render(assets, page).list();
+    var qtemp = ctx.request.getParameter('q') || '';
+    var searchQuery = utilsRequest.formatSearchQuery(qtemp);
+    output.searchQuery = searchQuery||'';
     caramel.render(output);
 }, request, response, session); %>

--- a/apps/publisher/themes/default/partials/list-assets.hbs
+++ b/apps/publisher/themes/default/partials/list-assets.hbs
@@ -40,7 +40,7 @@
         <div>
         <form class="form-group" id="assetSearchForm" action='{{url "/assets/"}}{{rxt.shortName}}/list' style="margin-left:-4px">
           <input type="text" name="query" class="" placeholder="{{t "Search asset by name ..."}}" id="inp_searchAsset"
-          value="{{paging.query}}" /><a type="button" href="#" class="btn-search" id="searchButton"><span class="fa fa-search"></span></a>
+          value="{{searchQuery}}" /><a type="button" href="#" class="btn-search" id="searchButton"><span class="fa fa-search"></span></a>
           <input type="hidden" name="sortby" value="{{paging.sortBy}}"/>
           <input type="hidden" name="sort" value="{{paging.sortOrder}}"/>
         </form>

--- a/apps/store/extensions/app/store-common/pages/top_assets.jag
+++ b/apps/store/extensions/app/store-common/pages/top_assets.jag
@@ -26,7 +26,7 @@ require('/modules/store.js').exec(function (ctx) {
     var user = server.current(ctx.session);
     var ui = require('rxt').ui;
     var tenantApi = require('/modules/tenant-api.js').api;
-    var assetApi = require('/modules/asset-api.js').api;
+    var utilsRequest = require('utils').request;
     var page = ui.buildPage(ctx.session, ctx.request);
     var appManager;
     var log = new Log();
@@ -66,7 +66,7 @@ require('/modules/store.js').exec(function (ctx) {
         }
     }
     var qtemp = ctx.request.getParameter('q') || '';
-    var searchQuery = assetApi.formatSearchQuery(qtemp);
+    var searchQuery = utilsRequest.formatSearchQuery(qtemp);
     output.searchQuery = searchQuery||'';
 
     caramel.render(output);

--- a/apps/store/extensions/assets/default/pages/list.jag
+++ b/apps/store/extensions/assets/default/pages/list.jag
@@ -48,6 +48,7 @@ require('/modules/store.js').exec(function(ctx) {
     var output = {};
     var tag = ctx.request.getParameter('tag');
     var assetApi = require('/modules/asset-api.js').api;
+    var utilsRequest = require('utils').request;
     var subscriptionApi = require('/modules/subscriptions-api.js').api;
     var tenantApi = require('/modules/tenant-api.js').api;
     var ratingApi = require('/modules/rating-api.js').api;
@@ -153,7 +154,7 @@ require('/modules/store.js').exec(function(ctx) {
     var output = am.render(assets, page).list();
     output.paging = assetApi.assetsPaging(assets, type, ctx.request);
     var qtemp = ctx.request.getParameter('q') || '';
-    var searchQuery = assetApi.formatSearchQuery(qtemp);
+    var searchQuery = utilsRequest.formatSearchQuery(qtemp);
     output.searchQuery = searchQuery||'';
     caramel.render(output);
 }, request, response, session); %>

--- a/apps/store/modules/asset-api.js
+++ b/apps/store/modules/asset-api.js
@@ -540,24 +540,5 @@ var responseProcessor = require('utils').response;
         paging.url = url;
         return paging;
     };
-    
-    api.formatSearchQuery = function (queryString) {
-        var searchQuery = "";
-        var qjson = parse('{' + queryString + '}');
-
-        var searchKeys = Object.keys(qjson);
-        if ((searchKeys.length === 1) && (searchKeys.indexOf("name") >= 0)) {
-            searchQuery += qjson[searchKeys.pop()];
-        }
-        else {
-            for (var keyIndex in searchKeys) {
-                var key = searchKeys[keyIndex];
-                var value = qjson[key];
-                searchQuery += key + ":" + value + " ";
-            }
-        }
-        searchQuery = searchQuery.trim();
-        return searchQuery;
-    };
 
 }(api))

--- a/jaggery-modules/utils/module/scripts/request/request.js
+++ b/jaggery-modules/utils/module/scripts/request/request.js
@@ -68,4 +68,24 @@ var log = new Log('request_module');
         });
         return obj;
     };
+    /*
+     * Format the encoded  query string and return user friendly search query
+     * */
+    request.formatSearchQuery = function (queryString) {
+        var searchQuery = "";
+        var qjson = parse('{' + queryString + '}');
+        var searchKeys = Object.keys(qjson);
+        if ((searchKeys.length === 1) && (searchKeys.indexOf("name") >= 0)) {
+            searchQuery += qjson[searchKeys.pop()];
+        }
+        else {
+            for (var keyIndex in searchKeys) {
+                var key = searchKeys[keyIndex];
+                var value = qjson[key];
+                searchQuery += key + ":" + value + " ";
+            }
+        }
+        searchQuery = searchQuery.trim();
+        return searchQuery;
+    }
 }(request))


### PR DESCRIPTION
Changes:
1.Move search query formatter logic to modules>utils>request library.making it more cleaner and less code repetition.
2. Apply same logic to publisher side as well, To retain the search query when result page get rendered.