### PR TITLE
Fix for REGISTRY-3278

### DIFF
--- a/apps/publisher/config/publisher.json
+++ b/apps/publisher/config/publisher.json
@@ -60,7 +60,9 @@
                 }
             },
             "basic": {
-                "attributes": {}
+                "attributes": {
+                    "loginURL":"%https.host%/publisher/pages/basic-auth-login"
+                }
             }
         }
     },

--- a/apps/publisher/controllers/login.jag
+++ b/apps/publisher/controllers/login.jag
@@ -37,24 +37,34 @@
     var resolveAuthMethod = function() {
         return config.authentication.activeMethod;
     };
-    var getRedirectURL = function(authMethod, context) {
+    var getBasicAuthLoginURL = function(method,config) {
+        var authDetails = config.authentication || {};
+        var details = authDetails.methods ? authDetails.methods[method] : null;
+        if(!details) {
+            log.error('Basic authentication details have not been specified.Please configure the basic authentication details in the publisher.json file.');
+            throw 'Basic authentication login URL has not been specified'
+        }
+        var attributes = details.attributes || {};
+        return attributes.loginURL;
+    };
+    var getRedirectURL = function(authMethod,context,config) {
         var url;
         var endpoint = '/pages/basic-auth-login';
         switch (authMethod) {
             case constants.AUTH_METHOD_BASIC:
-                endpoint = '/pages/basic-auth-login';
+                endpoint = getBasicAuthLoginURL (authMethod,config);
                 break;
             case constants.AUTH_METHOD_SSO:
-                endpoint = '/pages/sso-login';
+                endpoint = context + '/pages/sso-login';
                 break;
             case constants.AUTH_METHOD_OTHER:
-                endpoint = '/pages/other-login';
+                endpoint = context + '/pages/other-login';
                 break;
             default:
                 break;
         }
-        url = context + endpoint;
-        return url;
+        //url = endpoint;//context + endpoint;
+        return endpoint;
     };
     authMethod = resolveAuthMethod();
     if (!authMethod) {
@@ -64,7 +74,7 @@
         response.sendError(500);
         return;
     }
-    redirectURL = getRedirectURL(authMethod, context);
+    redirectURL = getRedirectURL(authMethod, context,config);
     if(queryString){
         redirectURL = redirectURL + "?" +  queryString;
     }

--- a/apps/store/config/store.json
+++ b/apps/store/config/store.json
@@ -37,7 +37,9 @@
                 }
             },
             "basic": {
-                "attributes": {}
+                "attributes": {
+                    "loginURL":"%https.host%/store/pages/basic-auth-login"
+                }
             }
         }
     }

--- a/apps/store/controllers/login.jag
+++ b/apps/store/controllers/login.jag
@@ -37,24 +37,34 @@
     var resolveAuthMethod = function() {
         return configs.authentication.activeMethod;
     };
-    var getRedirectURL = function(authMethod, context) {
+    var getBasicAuthLoginURL = function(method,config) {
+        var authDetails = config.authentication || {};
+        var details = authDetails.methods ? authDetails.methods[method] : null;
+        if(!details) {
+            log.error('Basic authentication details have not been specified.Please configure the basic authentication details in the publisher.json file.');
+            throw 'Basic authentication login URL has not been specified'
+        }
+        var attributes = details.attributes || {};
+        return attributes.loginURL;
+    };
+    var getRedirectURL = function(authMethod, context , config) {
         var url;
         var endpoint = '/pages/basic-auth-login';
         switch (authMethod) {
             case constants.AUTH_METHOD_BASIC:
-                endpoint = '/pages/basic-auth-login';
+                endpoint = getBasicAuthLoginURL (authMethod,config);
                 break;
             case constants.AUTH_METHOD_SSO:
-                endpoint = '/pages/sso-login';
+                endpoint = context + '/pages/sso-login';
                 break;
             case constants.AUTH_METHOD_OTHER:
-                endpoint = '/pages/other-login';
+                endpoint = context + '/pages/other-login';
                 break;
             default:
                 break;
         }
-        url = context + endpoint;
-        return url;
+        //url = context + endpoint;
+        return endpoint;
     };
     authMethod = resolveAuthMethod();
     if (!authMethod) {
@@ -63,7 +73,7 @@
         response.sendError(500);
         return;
     }
-    redirectURL = getRedirectURL(authMethod, context);
+    redirectURL = getRedirectURL(authMethod, context,configs);
     if(queryString){
         redirectURL = redirectURL + "?" +  queryString;
     }

--- a/apps/store/extensions/app/store-common/pages/basic-auth-login-controller.jag
+++ b/apps/store/extensions/app/store-common/pages/basic-auth-login-controller.jag
@@ -24,7 +24,7 @@ require('/modules/store.js').exec(function(ctx){
 	var ui = require('rxt').ui;
 	var refererHeader = ctx.request.getHeader('referer');
 	var page = ui.buildPage(ctx.session,ctx.request);
-	page.meta.referer = refererHeader;
+	page.meta.referer = require('utils').request.getURLPath(refererHeader);
 	caramel.render(page);
 },request,response,session);
 %>

--- a/jaggery-modules/utils/module/scripts/request/request.js
+++ b/jaggery-modules/utils/module/scripts/request/request.js
@@ -102,4 +102,11 @@ var log = new Log('request_module');
         return queryString.referer || '';
     };
 
+    /**
+     * Extracts the URL path from a URI
+     */
+    request.getURLPath = function(url) {
+        return  '/'+url.split('/').slice(3).join('/');
+    };
+
 }(request))


### PR DESCRIPTION
This PR redirects all login requests to an HTTPS endpoint.

**Changes**:
- Adds a loginURL property to the basic authentication configuration which is used to redirect the user to basic auth login page.
- The loginURL property is enriched using the https://github.com/wso2/carbon-store/blob/master/apps/publisher/config/publisher.js
- This script supports the following tokens:
   - %https.carbon.local.ip%
   - %http.carbon.local.ip%
   - %https.host%
   - %http.host%

Addresses the following issue: [REGISTRY-3278](https://wso2.org/jira/browse/REGISTRY-3278)