### PR TITLE
Fix for  REGISTRY-3028

### DIFF
--- a/apps/publisher/extensions/assets/default/asset.js
+++ b/apps/publisher/extensions/assets/default/asset.js
@@ -168,15 +168,6 @@ asset.configure = function() {
                     provider: {
                         auto: true
                     },
-                    name: {
-                        readonly: true,
-                        required:true,
-                        validation: function() {}
-                    },
-                    version: {
-                        readonly: true,
-                        required:true
-                    },
                     createdtime: {
                         hidden: true
                     }

--- a/extensions/gadget/gadget.rxt
+++ b/extensions/gadget/gadget.rxt
@@ -21,10 +21,10 @@
             <field type="text" required="true">
                 <name>Provider</name>
             </field>
-            <field type="text" required="true">
+            <field type="text" required="true" readonly="true">
                 <name>Name</name>
             </field>
-            <field type="text" required="true">
+            <field type="text" required="true" readonly="true">
                 <name>Version</name>
             </field>
             <field type="text">

--- a/extensions/site/site.rxt
+++ b/extensions/site/site.rxt
@@ -21,10 +21,10 @@
             <field type="text" required="true">
                 <name>Provider</name>
             </field>
-            <field type="text" required="true">
+            <field type="text" required="true" readonly="true">
                 <name>Name</name>
             </field>
-            <field type="text" required="true">
+            <field type="text" required="true" readonly="true">
                 <name>Version</name>
             </field>
             <field type="text">


### PR DESCRIPTION
This PR contains the following changes:
- Removed readonly override in the default asset.js
- Updated the gadget and site RXTs to make the name,provider and version fields readonly

Addresses the following issue: [REGISTRY-3028](https://wso2.org/jira/browse/REGISTRY-3028)