### PR TITLE
Fix for STORE-1195

### DIFF
--- a/apps/publisher/extensions/app/publisher-common/pages/basic-auth-logout-controller.jag
+++ b/apps/publisher/extensions/app/publisher-common/pages/basic-auth-logout-controller.jag
@@ -29,6 +29,7 @@
     }
     try {
         storeAPI.user.logout();
+        session.invalidate();
     } catch (e) {
         log.error('Unable to logout the user', e);
     }

--- a/apps/store/extensions/app/store-common/pages/basic-auth-logout-controller.jag
+++ b/apps/store/extensions/app/store-common/pages/basic-auth-logout-controller.jag
@@ -29,6 +29,7 @@
     }
     try {
         storeAPI.user.logout();
+        session.invalidate();
     } catch (e) {
         log.error('Unable to logout the user', e);
     }


### PR DESCRIPTION
This PR invalidates the session when a user logs out with basic authentication enabled.

Addresses the following issue:  [STORE-1195](https://wso2.org/jira/browse/STORE-1195)