### PR TITLE
Fix for REGISTRY-3404: Fix for tags 

### DIFF
--- a/apps/store/themes/store/css/left-navigation.css
+++ b/apps/store/themes/store/css/left-navigation.css
@@ -381,7 +381,7 @@ a.ctrl-filter-category:hover,a.ctrl-filter-category:focus
 
 }
 
-.tag-content > a > label {
+.tag-content > a > span {
     padding: 3px 8px;
     line-height: 19px;
     font-weight: 100;
@@ -392,7 +392,7 @@ a.ctrl-filter-category:hover,a.ctrl-filter-category:focus
     color: #333;
 }
 
-.tag-content > a > label:hover {
+.tag-content > a > span:hover {
     background-color: #C9E4FF;
     border: 1px solid #C9E4FF;
 }

--- a/apps/store/themes/store/partials/navigation.hbs
+++ b/apps/store/themes/store/partials/navigation.hbs
@@ -37,15 +37,15 @@
                             {{#each tags}}
                                     {{#if this.selected}}
                                         {{#if ../../assetCategoryDetails.hasCategories}}
-                                            <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><label class = "text-muted" >{{this.value}}</label></a>
+                                            <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><span class = "text-muted" >{{this.value}}</span></a>
                                         {{else}}
-                                            <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'><label class = "text-muted" >{{this.value}}</label></a>
+                                            <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'><span class = "text-muted" >{{this.value}}</span></a>
                                         {{/if}}
                                     {{else}}
                                         {{#if ../../assetCategoryDetails.hasCategories}}
-                                            <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><label>{{this.value}}</label></a>
+                                            <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><span>{{this.value}}</span></a>
                                         {{else}}
-                                            <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'><label>{{this.value}}</label></a>
+                                            <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'><span>{{this.value}}</span></a>
                                         {{/if}}
                                     {{/if}}
                             {{/each}}


### PR DESCRIPTION
This PR changes the tag rendering mechanism to use spans instead of labels.According the HTML specification anchor tags [1] cannot have interactive content [2].

*Reference*
[1] https://developer.mozilla.org/en/docs/Web/HTML/Element/a
[2] https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#interactive_content

This PR depends on: https://github.com/wso2/product-greg/pull/575

Addresses the issue: [REGISTRY-3404](https://wso2.org/jira/browse/REGISTRY-3404)