### PR TITLE
Fix for REGISTRY-3480: Remove `path`, undefined variable

### DIFF
--- a/jaggery-modules/rxt/module/scripts/permissions/permissions.js
+++ b/jaggery-modules/rxt/module/scripts/permissions/permissions.js
@@ -938,7 +938,7 @@ var permissions = {};
         var authorizer = userManager.authorizer;
 
         if(log.isDebugEnabled()){
-            log.debug('[permissions] checking permission ' + action + ' for ' + username + ' tenantId ' + tenantId + ' path ' + path);
+            log.debug('[permissions] checking permission ' + action + ' for ' + username + ' tenantId ' + tenantId);
         }
         authorized = checkPermissionString(username, permission, action, authorizer);
         if(log.isDebugEnabled()){


### PR DESCRIPTION
In this PR:
- Resolve the issue described in https://wso2.org/jira/browse/REGISTRY-3480