### PR TITLE
Fix for REGISTRY-3483

### DIFF
--- a/apps/store/extensions/app/social-reviews/themes/store/js/custom/review-sort.js
+++ b/apps/store/extensions/app/social-reviews/themes/store/js/custom/review-sort.js
@@ -34,7 +34,7 @@ var redrawReviews = function(sortBy, callback) {
         sortBy: sortBy,
         offset: 0,
         limit: 10,
-        randomq:generateRandomStr()
+        cacheBuster:generateCacheBuster()
     }, function(obj) {
         var reviews = obj || [];
         usingTemplate(function(template) {
@@ -57,7 +57,7 @@ var redrawReviews = function(sortBy, callback) {
  * the request URIs must be unique.This is achieved by generating 
  * a random query string
  */
-var generateRandomStr = function(){
+var generateCacheBuster = function(){
     return new Date().getTime();
 };
 $(document).on('click', '.com-sort a', function(e) {


### PR DESCRIPTION
This PR addresses an issue with social reviews in the IE browser. The issue prevents newly added issues from been visible in the UI.

*What was the cause of the issue?*
The issue is caused by IE 11 caching AJAX requests [1]. In order to circumvent this behavior the social API REST calls are now made with a unique query string.

**Reference**
[1] http://www.itworld.com/article/2693447/ajax-requests-not-executing-or-updating-in-internet-explorer-solution.html

Addresses the issue: [REGISTRY-3483](https://wso2.org/jira/browse/REGISTRY-3483)