### PR TITLE
Fix for REGISTRY-3489

### DIFF
--- a/apps/publisher/controllers/apis-router.jag
+++ b/apps/publisher/controllers/apis-router.jag
@@ -36,6 +36,7 @@ var mapper = function(path) {
     };
 };
 try{
+    response.addHeader('Cache-Control' ,'no-cache,no-store');
     metrics.start("apis-router","router");
     if (uriMatcher.match(API_URL)) {
         var args = uriMatcher.elements();

--- a/apps/store/controllers/apis-router.jag
+++ b/apps/store/controllers/apis-router.jag
@@ -35,6 +35,7 @@ var mapper = function(path) {
     };
 };
 try {
+    response.addHeader('Cache-Control' ,'no-cache,no-store');
     metrics.start("store-api-router","route");
     if (uriMatcher.match(API_URL)) {
         var args = uriMatcher.elements();


### PR DESCRIPTION
This PR adds a Cache-Control to prevent API responses from been cached by the browser.This was added to fix an issue with IE11 caching AJAX requests.

Addresses the following issue: [REGISTRY-3489](https://wso2.org/jira/browse/REGISTRY-3489)