### PR TITLE
Fix to allow assets to be created with file upload fields

### DIFF
--- a/apps/store/extensions/app/store-common/themes/store/css/basic-login-header.css
+++ b/apps/store/extensions/app/store-common/themes/store/css/basic-login-header.css
@@ -32,7 +32,7 @@ h2.app-title {
 
 .wr-app-bar {
     background:#237bd5;
-    height:54px;
+    height:40px;
 }
 
 header {

--- a/apps/store/themes/store/css/custom.css
+++ b/apps/store/themes/store/css/custom.css
@@ -228,7 +228,7 @@ div.asset-well div.advanced-search-form-container h1{
 
 .wr-app-bar {
     background: #237bd5;
-    height: 54px;
+    height: 40px;
     position: relative;
 }
 

--- a/jaggery-modules/rxt/module/scripts/asset/asset.js
+++ b/jaggery-modules/rxt/module/scripts/asset/asset.js
@@ -380,6 +380,12 @@ var asset = {};
             if(options.attributes.hasOwnProperty(constants.ASSET_PROVIDER)){
                 options.attributes[constants.ASSET_PROVIDER] = options.attributes[constants.ASSET_PROVIDER].replace('@', ':');
             }
+            //If the asset is retrieved via a get it will contain a content property
+            //which is used to invoke the GenericArtifact setContent method.This check will ensure
+            //that it is removed prior to calling the carbon/artifact.js 
+            if(options.hasOwnProperty('content')){
+                delete options.content;
+            }
             this.am.update(options);
             var asset = this.am.get(options.id);
             if (!this.rxtManager.isGroupingEnabled(this.type)) {


### PR DESCRIPTION
This PR addresses an issue which prevented file fields to be populated during asset creation (e.g. thumbnail and banner of the gadget rxt).

*What was the cause of the issue?*
- The AssetManager:get method returns a content property which wraps the GenericArtifact:getContent method
- When the update method is called the content property is passed causing the function to be serialized: https://github.com/wso2/jaggery-extensions/blob/master/carbon/module/scripts/registry/artifacts.js#L89
- This corrupts the asset

This functionality worked earlier as the asset-api.js script incorrectly did not use an asset instance obtained through the AssetManager:get method.However, this was fixed in commit : https://github.com/wso2/carbon-store/commit/e058a244e617a1e3ad816a60952fb7ea6b04f2c8