### PR TITLE
Fix for REGISTRY-3435

### DIFF
--- a/apps/publisher/jaggery.conf
+++ b/apps/publisher/jaggery.conf
@@ -1,7 +1,7 @@
 {
 	"initScripts":["app-scripts/init-scripts/app.js"],
     "sessionDestroyedListeners":["app-scripts/listeners/clearindex.js"],
-    "welcomeFiles":["/controllers/index-router.jag"],
+    "welcomeFiles":["controllers/index-router.jag"],
 	"logLevel": "info",
     "errorPages": {
         "500": "/controllers/error500.html",

--- a/apps/store/jaggery.conf
+++ b/apps/store/jaggery.conf
@@ -1,5 +1,5 @@
 {
-    "welcomeFiles":["/controllers/index.jag"],
+    "welcomeFiles":["controllers/index.jag"],
     "urlMappings": [
         {
             "url": "/modules/*",


### PR DESCRIPTION
This PR fixes an issue with the Publisher and Store applications displaying a blank page when a user navigates to /publisher or /store.

Addresses the following issue: [REGISTRY-3435](https://wso2.org/jira/browse/REGISTRY-3435)