### PR TITLE
Fix for STORE-1222

### DIFF
--- a/apps/store/modules/page-decorators.js
+++ b/apps/store/modules/page-decorators.js
@@ -333,8 +333,17 @@ var pageDecorators = {};
             'sortBy': '',
             'paginationLimit': 1000
         };
-        page.tags = doTermSearch(ctx,'tags', paging, true);
-        page.selectedTag = selectedTag(ctx);
+        //Obtain tenant aware resources 
+        var resources = tenantApi.createTenantAwareAssetResources(ctx.session, {
+            type: ctx.assetType
+        });
+        page.tags = doTermSearch(resources.context,'tags', paging, true);
+        page.selectedTag = selectedTag(resources.context);
+        //The tags applied to an asset should only be calculated
+        //for the details page
+        if((page.meta.pageName === 'details')&&(page.assets.id)){
+            page.appliedTags = appliedTags(resources.am,page.assets.id);
+        }
         return page;
     };
     pageDecorators.myAssets = function(ctx, page) {
@@ -691,6 +700,16 @@ var pageDecorators = {};
             selectedTag.url = searchPage;
             return selectedTag;
         }
+    };
+
+    /**
+     * Obtains all of the tags that have been applied to the asset
+     * @param  {Object} assetManager An AssetManager instance
+     * @param  {String} assetId     The Id of the asset for which tags should be retrieved
+     * @return {Array} An array of tag objects
+     */
+    var appliedTags = function(assetManager,assetId){
+        return assetManager.getTags(assetId) || [];
     };
 
     var generatePaginationContext = function(paging){

--- a/apps/store/themes/store/partials/tags.hbs
+++ b/apps/store/themes/store/partials/tags.hbs
@@ -13,10 +13,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-{{#if tags}}
-    <h4><i class="fa fw-tag"></i> {{t "Tags"}}</h4>
-    {{#itr tags}}
-        <a class="tags" href='{{url ""}}/assets/{{../rxt.shortName}}/list?q="tags":"{{value.value}}"'>{{value.value}}</a>
-    {{/itr}}
+{{#if appliedTags}}
+    <h4><i class="fa fw-tag"></i> {{t "Associated Tags"}}</h4>
+    {{#each appliedTags}}
+        <a class="tags" target='_blank' href='{{url ""}}/assets/{{../rxt.shortName}}/list?q="tags":"{{this}}"'>{{this}}</a>
+    {{/each}}
 {{/if}}


### PR DESCRIPTION
This PR includes the following changes:
1. Tags title in the asset details page has been changed to Applied Tags
2. Applied Tags no longer display all tags (similar to the tag cloud)

*Important* Corrected an issue with the way tags are retrieved.The existing approach for retrieving tags did not utilize tenant aware resources for supporting tenanted URLs (e.g. /t/foo.com).This has been fixed in this commit by utilizing the tenant-api.js.

Addresses the following issue: [STORE-1222](https://wso2.org/jira/browse/STORE-1222)