### PR TITLE
Fix for STORE-1239

### DIFF
--- a/apps/store/themes/store/partials/sort-assets.hbs
+++ b/apps/store/themes/store/partials/sort-assets.hbs
@@ -10,9 +10,6 @@
                     <img src="/publisher/themes/default/img/icons/ico-sort.png">
                 </a>
                 <ul aria-labelledby="dropdownMenu1" role="menu" class="dropdown-menu" id="ul-sort-assets" data-type="gadget">
-                    <li role="presentation" class="{{#if sorting.popularActive}}active{{/if}} sort-popular">
-                        <a href='{{tenantedUrl ""}}/assets/{{rxt.shortName}}/list?sort=popular' class="filter-item"><span class="pull-left">Popular</span> </a>
-                    </li>
                     <li role="presentation" class="{{#if sorting.nameActive}}active{{/if}} sort-name">
                         <a href='{{tenantedUrl ""}}/assets/{{rxt.shortName}}/list?sortBy=overview_name&sort={{sorting.nameNextSort}}' title='{{t "Sort by Alphabetical Order"}}'><span class="pull-left">Name</span> <i class="fa {{sorting.nameIcon}} pull-right"></i></a>
                     </li>


### PR DESCRIPTION
This PR removes sort by popularity functionality from the Store listing view.

Addresses the following issue: [STORE-1239](https://wso2.org/jira/browse/STORE-1239)