### PR TITLE
Fix for Store-1173, Implement configurable claim dialect.

### DIFF
--- a/apps/sso/config/app.js
+++ b/apps/sso/config/app.js
@@ -12,20 +12,21 @@ var event = require('event');
 var STORE_CONFIG_PATH = '/_system/config/sso/configs/sso.json';
 
 var server = require('/modules/server.js');
+var ssoTenantConfig = require('/config/sso-tenant.json');
 server.init(configs);
-
 var user = require('/modules/user.js');
+var storeModule = require('store');
 user.init(configs);
 
 var log = new Log();
 
+storeModule.server.init(configs);
+storeModule.user.init(configs);
 event.on('tenantCreate', function (tenantId) {
     var carbon = require('carbon'),
         system = server.systemRegistry(tenantId);
     system.put(STORE_CONFIG_PATH, {
-        content: JSON.stringify({
-            "permissions": configs.permissions
-        }),
+        content: JSON.stringify(ssoTenantConfig),
         mediaType: 'application/json'
     });
 });
@@ -45,3 +46,7 @@ event.on('tenantLoad', function (tenantId) {
         "permissions": configs.permissions
     };
 });
+
+//Cause the super tenant to be load
+var SUPER_TENANT = -1234;
+event.emit('tenantLoad', SUPER_TENANT);

--- a/apps/sso/config/sso-tenant.json
+++ b/apps/sso/config/sso-tenant.json
@@ -1,0 +1,4 @@
+{
+    "claimDialectUri": "http://wso2.org/claims",
+    "permissions": {}
+}

--- a/apps/sso/views/register_new_user.jag
+++ b/apps/sso/views/register_new_user.jag
@@ -89,8 +89,39 @@ var themeModule = require('/modules/theme.js');
                                     </div>
 
                                 <%
+                                    function getSsoConfig(tenantId) {
+                                        var server = require('store').server,
+                                                registry = server.systemRegistry(tenantId);
+                                        return JSON.parse(registry.content(SSO_TENANT_CONFIG_PATH));
+                                    }
+
+                                    function getTenantId(referrerURI) {
+                                        var constants = require('rxt').constants;
+                                        var urlTenantId = constants.DEFAULT_TENANT;
+
+                                        if (!referrerURI) {
+                                            <!-- If directly copy registration URL to the browser or in similar kind of event TODO: Use  tenanted URL pattern for registration as well -->
+                                            return urlTenantId;
+                                        }
+
+                                        var host = referrerURI.split('/')[2];
+                                        referrerURI = referrerURI.split(host)[1];
+                                        var uriMater = new URIMatcher(referrerURI);
+                                        var elements = uriMater.match(constants.TENANT_URL_PATTERN) || uriMater.match(constants.DEFAULT_SUPER_TENANT_URL_PATTERN);
+                                        var domain = elements.domain;
+                                        var carbon = require('carbon');
+                                        urlTenantId = carbon.server.tenantId({domain: domain}); //TODO: change this logic once tenanted URLs are introduced to publisher as well
+                                        return urlTenantId;
+                                    }
+                                    var SSO_TENANT_CONFIG_PATH = '/_system/config/sso/configs/sso.json';
+
+                                    var referrerURI = request.getHeader("referer");
+                                    var tenantId = getTenantId(referrerURI);
+
+                                    var ssoConfig = getSsoConfig(tenantId);
+
                                     var claimsModule = require('account-management');
-                                    var claims = claimsModule.getDefaultClaims();
+                                    var claims = claimsModule.getClaims(ssoConfig.claimDialectUri);
                                     var renderedClaims = {};
 
                                     var claimUriOverrides = {

--- a/jaggery-modules/rxt/module/scripts/asset/asset.js
+++ b/jaggery-modules/rxt/module/scripts/asset/asset.js
@@ -30,6 +30,7 @@
 var asset = {};
 (function(asset, core) {
     var log = new Log('rxt.asset');
+    var carbon = require('carbon');
     var DEFAULT_TIME_STAMP_FIELD = 'overview_createdtime'; //TODO:Move to constants
     var DEFAULT_RECENT_ASSET_COUNT = 5; //TODO: Move to constants
     var GovernanceUtils = Packages.org.wso2.carbon.governance.api.util.GovernanceUtils;


### PR DESCRIPTION
In this PR:

- Add configurable claim dialect feature to carbon store, With that, users can change the claim dialect which has been used for store registration form.

- Configuration file for define the claim dialect located in `/_system/config/sso/configs/sso.json`.
This PR resolve this [issue](https://wso2.org/jira/browse/Store-1173)