### PR TITLE
Fix for - REGISTRY-3589- State transition button not hiding in lifecycle UI

### DIFF
--- a/apps/publisher/themes/default/js/lifecycle/lifecycle-init.js
+++ b/apps/publisher/themes/default/js/lifecycle/lifecycle-init.js
@@ -414,14 +414,6 @@ $(function() {
             renderChecklistItems();
             return;
         }
-        if (!LifecycleAPI.lifecycle().isLCActionsPermitted) {
-            LifecycleAPI.notify(config(constants.MSG_WARN_CANNOT_CHANGE_STATE), {
-                type: constants.NOTIFICATION_WARN,
-                global: true
-            });
-            renderChecklistItems();
-            return;
-        }
         renderChecklistItems();
         renderLCActions();
         renderDeleteActions();


### PR DESCRIPTION
State transition button not hiding in lifeclcle checklist UI when a "forevent" checkbox is unchecked.