### PR TITLE
Fix for STORE-1112

### DIFF
--- a/apps/publisher/controllers/apis-router.jag
+++ b/apps/publisher/controllers/apis-router.jag
@@ -26,6 +26,7 @@ var log = new Log("apis_router");
 var responseProcessor = require('utils').response;
 var rxtAPI = require('rxt');
 var metrics = require('carbon-metrics').metrics;
+var msg;
 var getPage = function(uri) {
     var comps = uri.split('/');
     return comps.length > 0 ? comps[0] : null;
@@ -56,9 +57,12 @@ try{
                 request.getMappedPath = mapper(path);
                 var username = user ? user.username : null;
                 var isAuthorized = rxtAPI.permissions.hasAppAPIPermission(page,tenantId,username);
+                //We should send a 404 error as returning a 401 error would indicate
+                //that such an endpoint exists to attackers
                 if(!isAuthorized){
                     log.error('user '+username+' does not have permission to access the api '+page);
-                    response.sendError(401,'You do not have access to this api');
+                    msg = 'Unable to locate api : ' + args.suffix;
+                    response = responseProcessor.buildErrorResponse(response, 404, msg);
                 } else {
                     var proceed = app.execApiHandlers('onApiLoad', request, response, session, page);
                     if (proceed) {
@@ -66,7 +70,7 @@ try{
                     }
                 }
             } else {
-                var msg = 'Unable to locate mapped endpoint at path: ' + path;
+                msg = 'Unable to locate mapped endpoint at path: ' + path;
                 log.error(msg);
                 response = responseProcessor.buildErrorResponse(response, 404, msg);
             }

--- a/apps/store/controllers/apis-router.jag
+++ b/apps/store/controllers/apis-router.jag
@@ -20,6 +20,7 @@
 var API_URL = '/{context}/apis/{+suffix}';
 var DEFAULT_TENANT = -1234;
 var uriMatcher = new URIMatcher(request.getRequestURI());
+var responseProcessor = require('utils').response;
 var server = require('store').server;
 var metrics = require('carbon-metrics').metrics;
 var user = server.current(session);
@@ -56,7 +57,8 @@ try {
                 var isAuthorized = rxtAPI.permissions.hasAppAPIPermission(page, tenantId, username);
                 if (!isAuthorized) {
                     log.error('user ' + username + ' does not have permission to access the api ' + page);
-                    response.sendError(401,'You do not have access to this page');
+                    //response.sendError(401,'You do not have access to this page');
+                    response = responseProcessor.buildErrorResponse(response, 404, 'Unable to locate api : '+args.suffix);
                 } else {
                     var proceed = app.execApiHandlers('onApiLoad', request, response, session, page);
                     if (proceed) {


### PR DESCRIPTION
This PR causes a 404 error to be returned when an authorized user attempts to access a secured API endpoint.

The rationale behind the status code change is that an authorized user should not be able to guess the existence of an API endpoint by the use of the 401 status code.

Addresses the following issue: [STORE-1112](https://wso2.org/jira/browse/STORE-1112)