### PR TITLE
fix for STORE-1218: Change update asset request return code

### DIFF
--- a/apps/publisher/extensions/assets/default/apis/assets.jag
+++ b/apps/publisher/extensions/assets/default/apis/assets.jag
@@ -73,7 +73,7 @@ require('/modules/publisher.js').exec(function (ctx) {
         if (!updatedAsset) {
             return responseProcessor.buildErrorResponseDefault(constants.STATUS_CODES.NOT_FOUND, 'error on update api', res, 'No matching asset found by id : ' + options.id, 'this is more information', []);
         }
-        response = responseProcessor.buildSuccessResponseDefault(constants.STATUS_CODES.ACCEPTED, res, updatedAsset);
+        response = responseProcessor.buildSuccessResponseDefault(constants.STATUS_CODES.OK, res, updatedAsset);
     };
     var getAsset = function (options, req, res, session) {
         var asset = assetApi.get(options, req, res, session);


### PR DESCRIPTION
In this PR:

* Change the HTTP return code of the store publisher update asset POST request.
* Change the return code from HTTP [202](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.3) to HTTP [200](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) code

This resolve this store [issue](https://wso2.org/jira/browse/STORE-1218)