### PR TITLE
Fix for Store search not working

### DIFF
--- a/apps/store/extensions/assets/default/asset.js
+++ b/apps/store/extensions/assets/default/asset.js
@@ -39,7 +39,7 @@ asset.manager = function(ctx) {
             return query;
         }
         //TODO: Even though an array is sent in only the first search value is accepted
-        query.lcState=[publishedStates[0]];
+        query.lcState = publishedStates[0];
         return query;
     };
     return {

--- a/jaggery-modules/rxt/module/scripts/asset/asset.js
+++ b/jaggery-modules/rxt/module/scripts/asset/asset.js
@@ -576,6 +576,7 @@ var asset = {};
             //Drop the type property from the query
             if((query.hasOwnProperty(key)) && (key!='type')){
                 value = query[key];
+                value = String(value);
                 //If the key contains an underscore (_) we 
                 //need  replace it with a semi colon (:)
                 //as the underlying API requires this


### PR DESCRIPTION
This PR fixes an issue with the Store search not returning any results.The cause of the issue was two fold:
1. The published state was been provided to the query as an array, this caused issues when creating the query string
2. The query value was been provided as a Java string  