### PR TITLE
Fix for STORE-1257

### DIFF
--- a/apps/publisher/modules/asset-api.js
+++ b/apps/publisher/modules/asset-api.js
@@ -332,7 +332,7 @@ var result;
                 throw 'Required field not provided';
             } else {
                 //Populate a dummy value for the purpose of creating the asset
-                asset.attributes[fieldName] = fieldName;
+                asset.attributes[fieldName] = assetManager.getFileFieldPlaceholder();
             }
         });
     };

--- a/jaggery-modules/rxt/module/scripts/asset/asset.js
+++ b/jaggery-modules/rxt/module/scripts/asset/asset.js
@@ -1700,6 +1700,10 @@ var asset = {};
                 }
                 return '';
             }
+            //Check if only a placeholder is specified
+            if(thumb === this.getFileFieldPlaceholder()){
+                return '';
+            }
             return asset.attributes[thumbnailAttribute];
         }
         return '';
@@ -1712,6 +1716,10 @@ var asset = {};
                 if (log.isDebugEnabled()) {
                     log.debug('Unable to locate bannerAttribute ' + bannerAttribute + ' in asset ' + asset.id);
                 }
+                return '';
+            }
+            //Check if only a placeholder is specified
+            if(banner === this.getFileFieldPlaceholder()){
                 return '';
             }
             return asset.attributes[bannerAttribute];
@@ -1739,6 +1747,13 @@ var asset = {};
      */
     AssetManager.prototype.getAssetResources = function() {
         return this.rxtManager.listRxtFieldsOfType(this.type, 'file');
+    };
+    /**
+     * Returns the placeholder value used for file type fields
+     * @return {[type]} [description]
+     */
+    AssetManager.prototype.getFileFieldPlaceholder = function(){
+        return 'no-file-specified';
     };
     AssetManager.prototype.importAssetFromHttpRequest = function(options) {
         var asset = {};


### PR DESCRIPTION
Identify scenarios where a user does not upload a file type field for thumbnails and banners

This fix involves the following steps:
1. All file type fields are assigned a place holder string which is overriden by the field name when a file is given
2. The placeholder is considered when retrieving the thumbnail and banner attributes

Addresses the following issue: [STORE-1257](https://wso2.org/jira/browse/STORE-1257)