### PR TITLE
Fix for STORE-1262 ; Disable tab click state when user visit a tab

### DIFF
--- a/apps/publisher/themes/default/css/custom.css
+++ b/apps/publisher/themes/default/css/custom.css
@@ -1285,3 +1285,9 @@ sup.required-field{
     .form-search a.advance i { line-height: 35px; padding-bottom: 5px; }
     .form-search a.advance span { display: inline-block; }
 }
+
+.tab-selected {
+    pointer-events: none;
+    cursor: default;
+    background-color: #1965b2;
+}

--- a/apps/publisher/themes/default/js/popover.js
+++ b/apps/publisher/themes/default/js/popover.js
@@ -48,19 +48,19 @@ var currentPageFunction = (function(){
     returnObj.init = function(){
         switch(store.publisher.currentPage) {
             case "details":
-                $(".btn-overview").css("background-color","#1965b2");
+                $(".btn-overview").addClass("tab-selected");
                 break;
             case "copy":
-                $(".btn-copy").css("background-color","#1965b2");
+                $(".btn-copy").addClass("tab-selected");
                 break;
             case "update":
-                $(".btn-edit").css("background-color","#1965b2");
+                $(".btn-edit").addClass("tab-selected");
                 break;
             case "delete":
-                $(".btn-delete").css("background-color","#1965b2");
+                $(".btn-delete").addClass("tab-selected");
                 break;
             case "lifecycle":
-                $(".btn-lifecycle").css("background-color","#1965b2");
+                $(".btn-lifecycle").addClass("tab-selected");
                 break;
         }
     };


### PR DESCRIPTION
In this PR:

- Disable the clickable state of the tab in publisher asset actions ribbon(edit,version,life cycle...),So that    when user click back on the action which they currently in it didn't hit back to the same page

Addresses the following issue: [STORE-1262](https://wso2.org/jira/browse/STORE-1262)