### PR TITLE
Fix for Store-1266, Add a missing separator colon and flip username icon position with username text

### DIFF
--- a/apps/publisher/themes/default/partials/header.hbs
+++ b/apps/publisher/themes/default/partials/header.hbs
@@ -11,7 +11,8 @@
         		<div class="wr-auth pull-right">
         			<a href="#" data-toggle="dropdown" class="">
         				<div class="auth-img">
-        					<span>{{cuser.username}}</span>&nbsp;&nbsp;<i class="fw fw-user fw-lg"></i>
+                            <i class="fw fw-user fw-lg"></i>&nbsp;&nbsp;
+                            <span>{{cuser.username}}</span>
         				</div>
         			</a>
         			<div class="dropdown-menu">

--- a/apps/publisher/themes/default/partials/tag-ui-container.hbs
+++ b/apps/publisher/themes/default/partials/tag-ui-container.hbs
@@ -1,6 +1,6 @@
 <div id='tag-ui'>
     <div class="form-group">
-        <label class="custom-form-label col-lg-2 col-md-2 col-sm-12 col-xs-12">Tags</label>
+        <label class="custom-form-label col-lg-2 col-md-2 col-sm-12 col-xs-12 text-right">Tags : </label>
         <div class="custom-form-right col-lg-5 col-md-8 col-sm-8 col-xs-12">
             <select class='tag-ui-selectbox form-control' multiple name='_tags' style="width:100%;">
                 {{#each assetTags}}


### PR DESCRIPTION
In this PR:
* Add a missing separator colon in between tag label and its input box.
* Flip the position of username text and icon.

Addresses the following issue: [STORE-1266](https://wso2.org/jira/browse/STORE-1266)