### PR TITLE
Fix for STORE-1267

### DIFF
--- a/apps/store/modules/page-decorators.js
+++ b/apps/store/modules/page-decorators.js
@@ -326,6 +326,10 @@ var pageDecorators = {};
         page.popularAssets = items;
     };
     pageDecorators.tags = function(ctx, page) {
+        //Avoid generating tags if there is no asset types
+        if(!ctx.assetType) {
+            return;
+        }
         var paging = {
             'start': 0,
             'count': 0,

--- a/apps/store/themes/store/partials/navigation.hbs
+++ b/apps/store/themes/store/partials/navigation.hbs
@@ -31,6 +31,7 @@
                             {{/each}}
                         {{/with}}
                     </nav>
+                    {{#if tags}}
                     <div class="tags-wrapper">
                         <div class="tag-title"> Tags </div>
                         <div class="tag-content">
@@ -51,6 +52,7 @@
                             {{/each}}
                         </div>
                     </div>
+                    {{/if}}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Disabled tags for the top assets page

Addresses the following issue: [STORE-1267](https://wso2.org/jira/browse/STORE-1267)