### PR TITLE
fix for STORE-1264, createdtime value get tampered when updating an asset

### DIFF
--- a/apps/publisher/modules/asset-api.js
+++ b/apps/publisher/modules/asset-api.js
@@ -173,7 +173,7 @@ var result;
 
                 //Determine if the field is readonly or auto.if yes then ignore
                 //the user provided value and use the original value
-                if((definition.readonly)||(definition.auto)){
+                if((definition.readonly)||(definition.auto)||(definition.hidden)){
                     asset.attributes[key] = original.attributes[key];
                 }
 


### PR DESCRIPTION
In this PR:

*  Update if condition to accept hidden attributes to override the original value with in the updating asset 

Addresses the following issue: [STORE-1264](https://wso2.org/jira/browse/STORE-1264)