### PR TITLE
Fix for Store-1278: Add not deleteable warning information

### DIFF
--- a/apps/publisher/themes/default/css/custom-theme.css
+++ b/apps/publisher/themes/default/css/custom-theme.css
@@ -486,3 +486,56 @@ a.ctrl-filter-category:hover {
     -webkit-border-radius: 0px!important;
     -moz-border-radius: 0px!important;
 }
+
+/* ========================================================================
+ * message styles
+ * ======================================================================== */
+.message {
+    padding: 20px;
+    margin: 20px 0;
+    border-left: 5px solid transparent;
+    background: #f9f9f9;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    border-radius: 0;
+}
+.message h4 {
+    font-weight: 300;
+    margin-top: 0;
+    margin-bottom: 5px;
+}
+.message h4 .icon {
+    padding-bottom: 3px;
+    margin-right: 5px;
+}
+.message p:last-child {
+    margin-bottom: 0;
+}
+.message + .message {
+    margin-top: -5px;
+}
+
+.message-success {
+    border-left-color: #5cb85c;
+}
+.message-success h4 {
+    color: #5cb85c;
+}
+.message-info {
+    border-left-color: #009DA7;
+}
+.message-info h4 {
+    color: #009DA7;
+}
+.message-warning {
+    border-left-color: #f0ad4e;
+}
+.message-warning h4 {
+    color: #f0ad4e;
+}
+.message-danger {
+    border-left-color: #d9534f;
+}
+.message-danger h4 {
+    color: #d9534f;
+}

--- a/apps/publisher/themes/default/js/delete-asset.js
+++ b/apps/publisher/themes/default/js/delete-asset.js
@@ -55,9 +55,9 @@ var enableDelete = function () {
 };
 
 var disableDelete = function (msg) {
-    $('#Delete').addClass('not-active').attr("title", msg).click(function (e) {
-        e.preventDefault()
-    });
+    var deletePanel = $('.message.message-danger');
+    deletePanel.removeClass('message-danger').addClass('message-warning');
+    deletePanel.find('.fw.fw-error').removeClass('fw-error').addClass('fw-warning');
 
     $('#btn-delete-con').hide();
     $('#delete-msg').text('Asset is not in a deletable state');

--- a/apps/publisher/themes/default/js/lifecycle/lifecycle-init.js
+++ b/apps/publisher/themes/default/js/lifecycle/lifecycle-init.js
@@ -275,7 +275,7 @@ $(function() {
                 $(id(container)).removeClass('not-active').removeAttr("title").unbind('click');
                 return;
             }
-            $(id(container)).addClass('not-active').attr("title", "Asset is not in a deletable State!")
+            $(id(container)).attr("title", "Asset is not in a deletable State!")
                 .click(function (e) {
                     e.preventDefault()
                 });

--- a/apps/publisher/themes/default/partials/delete-asset.hbs
+++ b/apps/publisher/themes/default/partials/delete-asset.hbs
@@ -19,23 +19,27 @@
                         <p>{{lifecycle}} : {{lifecycleState}}</p>
                     {{/if}}
                     {{#if createdDate}}
-                    <div class="well-description">{{createdDate}}</div>
+                        <div class="well-description">{{createdDate}}</div>
                     {{/if}}
                 </div>
             </div>
         </div>
     </div>
 {{/with}}
-<div class="delete" id="deleteModal" >
+<div class="delete" id="deleteModal">
     <div class="form-inline">
-          <p id="delete-msg">{{t "Do you want to delete "}}<b>{{assets.name}}</b>{{t " "}}{{rxt.singularLabel}}{{t "?"}}</p>
-          <input type="hidden" id="asset-id" value="{{assets.id}}">
-          <input type="hidden" id="asset-name" value="{{assets.name}}">
-          <input type="hidden" id="asset-type" value="{{assets.type}}">
-          <input type="hidden" id="landing-page" value="{{meta.landingPage}}">
-          <i class="fa fa-spinner fa-spin fa-3x hide" id="delete-loading"></i>
-          <br/>
-          <button type="button" id="btn-delete-con" class="btn btn-danger" >{{t "Delete"}}</button>
-          <button type="button" id="btn-cancel-con" class="btn btn-primary" >{{t "Cancel"}}</button>
+        <div class="message message-danger">
+            <h4><i class="icon fw fw-error"></i>Asset deletion</h4>
+            <p id="delete-msg">{{t "Do you want to delete "}}
+                <b>{{assets.name}}</b>{{t " "}}{{rxt.singularLabel}}{{t "?"}}</p>
+        </div>
+        <input type="hidden" id="asset-id" value="{{assets.id}}">
+        <input type="hidden" id="asset-name" value="{{assets.name}}">
+        <input type="hidden" id="asset-type" value="{{assets.type}}">
+        <input type="hidden" id="landing-page" value="{{meta.landingPage}}">
+        <i class="fa fa-spinner fa-spin fa-3x hide" id="delete-loading"></i>
+        <br/>
+        <button type="button" id="btn-delete-con" class="btn btn-danger">{{t "Delete"}}</button>
+        <button type="button" id="btn-cancel-con" class="btn btn-primary">{{t "Cancel"}}</button>
     </div>
 </div>

--- a/apps/publisher/themes/default/partials/delete-asset.hbs
+++ b/apps/publisher/themes/default/partials/delete-asset.hbs
@@ -40,6 +40,6 @@
         <i class="fa fa-spinner fa-spin fa-3x hide" id="delete-loading"></i>
         <br/>
         <button type="button" id="btn-delete-con" class="btn btn-danger">{{t "Delete"}}</button>
-        <button type="button" id="btn-cancel-con" class="btn btn-primary">{{t "Cancel"}}</button>
+        <button type="button" id="btn-cancel-con" class="btn btn-default">{{t "Cancel"}}</button>
     </div>
 </div>


### PR DESCRIPTION
In this PR:

* Add `message` and `message-*` style classes from wso2-theme styling to publisher `custom-theme.css`

* Make delete button clickable from life-cycle tab, since we display the reason for why the asset can't delete

* Make the delete confirmation message accordance with new wso2-theme message styling 


Addresses the following issue: [STORE-1278](https://wso2.org/jira/browse/STORE-1278)