### PR TITLE
fix for STORE-1281;Fix issues in asset delete page 

### DIFF
--- a/apps/publisher/themes/default/js/delete-asset-con.js
+++ b/apps/publisher/themes/default/js/delete-asset-con.js
@@ -40,6 +40,7 @@ $(document).ready(function() {
                 $('#btn-cancel-con').addClass('hide ');
                 $('#delete-loading').addClass('hide');
                 $('#delete-msg').addClass('hide');
+                $('.message.message-danger').hide();
                 setTimeout(function(){
                     var path = caramel.url('/assets/'+assetType + '/list');
                     window.location = path;

--- a/apps/publisher/themes/default/js/delete-asset.js
+++ b/apps/publisher/themes/default/js/delete-asset.js
@@ -50,6 +50,8 @@ $(document).ready(function () {
 });
 
 var enableDelete = function () {
+    var deletePanel = $('.message.message-danger');
+    deletePanel.css('display','');
     $('#Delete').removeClass('not-active').removeAttr("title").unbind('click');
     $('#btn-delete-con').show();
 };
@@ -58,6 +60,7 @@ var disableDelete = function (msg) {
     var deletePanel = $('.message.message-danger');
     deletePanel.removeClass('message-danger').addClass('message-warning');
     deletePanel.find('.fw.fw-error').removeClass('fw-error').addClass('fw-warning');
+    deletePanel.css('display','');
 
     $('#btn-delete-con').hide();
     $('#delete-msg').text('Asset is not in a deletable state');

--- a/apps/publisher/themes/default/js/lifecycle/lifecycle-init.js
+++ b/apps/publisher/themes/default/js/lifecycle/lifecycle-init.js
@@ -275,10 +275,7 @@ $(function() {
                 $(id(container)).removeClass('not-active').removeAttr("title").unbind('click');
                 return;
             }
-            $(id(container)).attr("title", "Asset is not in a deletable State!")
-                .click(function (e) {
-                    e.preventDefault()
-                });
+            $(id(container)).attr("title", "Asset is not in a deletable State!");
         }
     };
     var unrenderLCActions = function() {

--- a/apps/publisher/themes/default/partials/delete-asset.hbs
+++ b/apps/publisher/themes/default/partials/delete-asset.hbs
@@ -28,7 +28,7 @@
 {{/with}}
 <div class="delete" id="deleteModal">
     <div class="form-inline">
-        <div class="message message-danger">
+        <div class="message message-danger" style="display: none">
             <h4><i class="icon fw fw-error"></i>Asset deletion</h4>
             <p id="delete-msg">{{t "Do you want to delete "}}
                 <b>{{assets.name}}</b>{{t " "}}{{rxt.singularLabel}}{{t "?"}}</p>


### PR DESCRIPTION
In this PR:

* Delete page message box set initial `display` property to `none`
* Remove `preventDefault` call in `lifecycle-init` which disable the delete button from lifecycle page
* Hide the message panel on the success call from the delete AJAX request

Addresses the following issue: [STORE-1281](https://wso2.org/jira/browse/STORE-1281)