### PR TITLE
Fix for Store-1284 : User can edit the option-text and option field even they have readonly attribute true

### DIFF
--- a/apps/publisher/themes/default/theme.js
+++ b/apps/publisher/themes/default/theme.js
@@ -347,7 +347,7 @@ var engine = caramel.engine('handlebars', (function() {
                         var optionValue = value.substr(0,value.indexOf(':'));
                         var textValue = value.substr(value.indexOf(':')+1);
                         var values = value.split(":");
-                        out = elementPrefix + renderOptionsForOptionsText(optionValue, field.values[0].value, field) + elementSuffix;
+                        out = elementPrefix + renderOptionsForOptionsText(optionValue, field.values[0].value, field, mode) + elementSuffix;
                         out += elementPrefix + '<input type="text" value="' + Handlebars.Utils.escapeExpression(textValue) + '" ' + renderFieldMetaData(field, field.name.tableQualifiedName+'_text', mode) + ' />' + elementSuffix;
                         break;
                     case 'text':

--- a/apps/publisher/themes/default/theme.js
+++ b/apps/publisher/themes/default/theme.js
@@ -233,7 +233,7 @@ var engine = caramel.engine('handlebars', (function() {
                 var isUpdatable = true;
 
                 var mode = 'create';
-                if(options && options.hash && options.hash.mode && options.hash.mode == "edit" || options == "edit"){
+                if(options && options.hash && options.hash.mode && options.hash.mode == "edit"){
                     mode = "edit";
                 }
 
@@ -344,6 +344,12 @@ var engine = caramel.engine('handlebars', (function() {
                         out = elementPrefix + renderOptions(field.value, field.values[0].value, field, mode) + elementSuffix;
                         break;
                     case 'option-text':
+                        var options = {
+                            'hash': {
+                                'mode': mode
+                            }
+                        };
+                        mode = options;
                         var optionValue = value.substr(0,value.indexOf(':'));
                         var textValue = value.substr(value.indexOf(':')+1);
                         var values = value.split(":");

--- a/apps/publisher/themes/default/theme.js
+++ b/apps/publisher/themes/default/theme.js
@@ -233,7 +233,7 @@ var engine = caramel.engine('handlebars', (function() {
                 var isUpdatable = true;
 
                 var mode = 'create';
-                if(options && options.hash && options.hash.mode && options.hash.mode == "edit"){
+                if(options && options.hash && options.hash.mode && options.hash.mode == "edit" || options == "edit"){
                     mode = "edit";
                 }
 
@@ -287,9 +287,9 @@ var engine = caramel.engine('handlebars', (function() {
                 }
                 return output;
             };
-            var renderOptions = function(value, values, field,count) {
+            var renderOptions = function(value, values, field, mode, count) {
                 var id=(count)?field.name.tableQualifiedName+'_option_'+count:undefined;
-                var out = '<select ' + renderFieldMetaData(field,id) + '>';
+                var out = '<select ' + renderFieldMetaData(field,id,mode) + '>';
 
                 for (var index in values) {
                     if (value && values[index].value == value) {
@@ -304,9 +304,9 @@ var engine = caramel.engine('handlebars', (function() {
             };
 
 
-            var renderOptionsForOptionsText = function(value, values, field) {
+            var renderOptionsForOptionsText = function(value, values, field,mode) {
                 var id=field.name.tableQualifiedName+'_option';
-                var out = '<select ' + renderFieldMetaData(field,id) + '>';
+                var out = '<select ' + renderFieldMetaData(field,id,mode) + '>';
 
                 for (var index in values) {
                     if (value && values[index].value == value) {
@@ -341,7 +341,7 @@ var engine = caramel.engine('handlebars', (function() {
                 }
                 switch (field.type) {
                     case 'options':
-                        out = elementPrefix + renderOptions(field.value, field.values[0].value, field) + elementSuffix;
+                        out = elementPrefix + renderOptions(field.value, field.values[0].value, field, mode) + elementSuffix;
                         break;
                     case 'option-text':
                         var optionValue = value.substr(0,value.indexOf(':'));
@@ -537,9 +537,9 @@ var engine = caramel.engine('handlebars', (function() {
                 var type = options.hash.type;
                 var tenantId = options.hash.tenantId;
                 var username = options.hash.username;
-                var isAuthorized =options.hash.auth ? options.hash.auth : false; 
+                var isAuthorized =options.hash.auth ? options.hash.auth : false;
                 var missingParams = (!key) || (!type) || (!tenantId) || (!username);
-                //If the user is forcing the view to render 
+                //If the user is forcing the view to render
                 if(isAuthorized){
                     return options.fn(context);
                 }
@@ -560,9 +560,9 @@ var engine = caramel.engine('handlebars', (function() {
                 var type = options.hash.type;
                 var tenantId = options.hash.tenantId;
                 var username = options.hash.username;
-                var isAuthorized =options.hash.auth ? options.hash.auth : false; 
+                var isAuthorized =options.hash.auth ? options.hash.auth : false;
                 var missingParams = (!key) || (!tenantId) || (!username);
-                //If the user is forcing the view to render 
+                //If the user is forcing the view to render
                 if(isAuthorized){
                     return options.fn(context);
                 }


### PR DESCRIPTION
In this PR:

* Add `or` logic to check the page request more whether it is an edit call
* Update `renderOptionsForOptionsText` and `renderOptions` methods to accept `mode` parameter 
* Change the method invocation according to send `mode` parameter with them

Addresses the following issue: [STORE-1284](https://wso2.org/jira/browse/STORE-1284)