### PR TITLE
Fix for STORE-873: update placeholder text with asset pluralLabel

### DIFF
--- a/apps/publisher/themes/default/partials/copy-asset.hbs
+++ b/apps/publisher/themes/default/partials/copy-asset.hbs
@@ -23,7 +23,7 @@
 {{/with}}
 <div class="copy" id="newVersionModal" >
     <div>
-        <p id="delete-msg" class="">{{t "Do you want to create a new version of "}} <b>{{assets.name}}{{t " "}}</b>{{rxt.singularLabel}}{{t "?"}}</p>
+        <p id="delete-msg" class="">{{t "Do you want to create a new version of the "}} <b>{{assets.name}}{{t " "}}</b>{{rxt.singularLabel}}{{t "?"}}</p>
         <div class='form-inline'>
             <div class='form-group'>
                 <label>{{t "Version"}} : </label>

--- a/apps/publisher/themes/default/partials/list-assets.hbs
+++ b/apps/publisher/themes/default/partials/list-assets.hbs
@@ -39,9 +39,14 @@
     <div class="wr-search">
         <form class="form-group" id="assetSearchForm" action='{{url "/assets/"}}{{rxt.shortName}}/list'>
           <div class="form-group has-feedback form-search">
-            <input type="text" name="query" class="form-control" placeholder="{{t "Search..."}}" id="inp_searchAsset"
-            value="{{searchQuery}}" />
-            <a href="#" class="form-control-feedback search" id="searchButton" class="fa fa-search" title="Search">
+        {{#if rxt.pluralLabel}}
+            <input type="text" name="query" class="form-control" placeholder="Search in {{rxt.pluralLabel}}"
+                   id="inp_searchAsset" value="{{searchQuery}}" />
+        {{else}}
+            <input type="text" name="query" class="form-control" placeholder="Search in all asset types"
+                   id="inp_searchAsset" value="{{searchQuery}}" />
+        {{/if}}
+              <a href="#" class="form-control-feedback search" id="searchButton" class="fa fa-search" title="Search">
                 <i class="fa fa-search" aria-hidden="true"></i>
             </a>
             <a id="advance-search" href="{{url ""}}/pages/advanced-search" class="form-control-feedback advance" title="Advanced Search">


### PR DESCRIPTION
In this PR:

* Add asset plural label to their landing page search input box
* Fixed typo in publisher asset copy(create new version) page

Addresses the following issue: [STORE-873](https://wso2.org/jira/browse/STORE-873)