### PR TITLE
Fix for STORE-1310

### DIFF
--- a/apps/store/extensions/assets/default/pages/list.jag
+++ b/apps/store/extensions/assets/default/pages/list.jag
@@ -63,7 +63,7 @@ require('/modules/store.js').exec(function(ctx) {
     PAGING.paginationLimit = (paginationLimit || constants.DEFAULT_ASSET_PAGIN.paginationLimit);
 
     //search history dropdown updates
-    if (count && q) {
+    if (q) {
         var searchQuery = decodeURIComponent(utilsRequest.formatSearchQuery(q));
         userApi.updateSearchHistory(ctx.session, searchQuery, type);
     }


### PR DESCRIPTION
The query submitted to the listing page is always added to the search history

Addresses the following issue: [STORE-1310](https://wso2.org/jira/browse/STORE-1310)