### PR TITLE
Fix for STORE-1307: Fix top_assets page search history issue

### DIFF
--- a/apps/store/themes/store/code/search-history.hbs
+++ b/apps/store/themes/store/code/search-history.hbs
@@ -1,0 +1,6 @@
+<script type="text/javascript">
+    if(!store.store){
+       store.store = {};
+    }
+    store.store.searchHistory = "{{searchHistory.queries}}";
+</script>

--- a/apps/store/themes/store/code/store.asset.hbs
+++ b/apps/store/themes/store/code/store.asset.hbs
@@ -13,9 +13,4 @@
     }
     store.security = {{#if security}}{{json security}}{{else}}null{{/if}};
     store.security.details ={};
-
-    if(!store.store){
-       store.store = {};
-    }
-    store.store.searchHistory = "{{searchHistory.queries}}";
 </script>

--- a/apps/store/themes/store/helpers/asset.js
+++ b/apps/store/themes/store/helpers/asset.js
@@ -20,7 +20,7 @@ var resources = function (page, meta) {
     return {
         js: ['jquery.rating.pack.js', 'async.min.js', 'asset-core.js', 'asset.js','porthole.min.js'],
         css: ['jquery.rating.css', 'asset.css'],
-        code: ['store.asset.hbs']
+        code: ['store.asset.hbs', 'search-history.hbs']
     };
 };
 

--- a/apps/store/themes/store/helpers/assets.js
+++ b/apps/store/themes/store/helpers/assets.js
@@ -20,7 +20,7 @@ var resources = function (block, page, area, meta) {
     return {
         template: 'assets.hbs',
         js: ['asset-core.js', 'asset-helpers.js', 'assets.js'],
-        code: ['store.asset.hbs']
+        code: ['store.asset.hbs', 'search-history.hbs']
     };
 };
 

--- a/apps/store/themes/store/helpers/top_assets.js
+++ b/apps/store/themes/store/helpers/top_assets.js
@@ -21,6 +21,6 @@ var resources = function (page, meta) {
         template: 'top-assets.hbs',
         js: ['asset-core.js', 'top-assets.js' ],
         css: ['top-assets.css'],
-        code: ['store.asset.hbs']
+        code: ['search-history.hbs']
     };
 };

--- a/apps/store/themes/store/helpers/top_assets.js
+++ b/apps/store/themes/store/helpers/top_assets.js
@@ -20,6 +20,7 @@ var resources = function (page, meta) {
     return {
         template: 'top-assets.hbs',
         js: ['asset-core.js', 'top-assets.js' ],
-        css: ['top-assets.css']
+        css: ['top-assets.css'],
+        code: ['store.asset.hbs']
     };
 };


### PR DESCRIPTION
In this PR:
*  Include `search-history.hbs` inline script to top_asset page
*  Move search history JS variable initialization to different partial

Addresses the following issue: [STORE-1307](https://wso2.org/jira/browse/STORE-1307)