### PR TITLE
Fix for STORE-1319: [Publisher] Adjust image thumbnail size and alignment to fit with the context

### DIFF
--- a/apps/publisher/themes/default/css/custom-theme.css
+++ b/apps/publisher/themes/default/css/custom-theme.css
@@ -268,6 +268,9 @@ a.ctrl-filter-category:hover {
     left: 0;
     right: 0;
     bottom: 0;
+    /* Overriding styles, applies from bootstrap .img-thumbnail class */
+    border: none;
+    border-radius: 0;
 }
 
 

--- a/apps/publisher/themes/default/css/custom.css
+++ b/apps/publisher/themes/default/css/custom.css
@@ -1373,4 +1373,5 @@ sup.required-field{
 }
 .thumbnail-width-fixer{
     max-width: 200px;
+    margin-right: 10px;
 }

--- a/apps/publisher/themes/default/partials/asset-thumbnail.hbs
+++ b/apps/publisher/themes/default/partials/asset-thumbnail.hbs
@@ -5,7 +5,7 @@
        </span>
 
         <div class="ast-name-img">
-            <img alt="thumbnail" class="square-element" src='{{url ""}}/storage/{{type}}/{{id}}/{{this.thumbnail}}'>
+            <img alt="thumbnail" class="square-element img-thumbnail" src='{{url ""}}/storage/{{type}}/{{id}}/{{this.thumbnail}}'>
         </div>
     </div>
 {{else}}


### PR DESCRIPTION
In this PR:

*  Add bootstrap `img-thumbnail` class to align the image thumbnail
* Add right margin to image thumbnail container to make some space between asset details element

Addresses the following issue: [STORE-1319](https://wso2.org/jira/browse/STORE-1319)