### PR TITLE
Fix for STORE-1321: Make configurable sort fields for publisher

### DIFF
--- a/apps/publisher/extensions/assets/default/asset.js
+++ b/apps/publisher/extensions/assets/default/asset.js
@@ -218,11 +218,11 @@ asset.configure = function() {
                 }
             },
             sorting: {
-                names: [
-                    {field: "overview_name", label: "Name"},
-                    {field: "overview_version", label: "Version"},
-                    {field: "overview_provider", label: "Provider"},
-                    {field: "createdDate", label: "Date/Time"}]
+                attributes: [
+                    {name: "overview_name", label: "Name"},
+                    {name: "overview_version", label: "Version"},
+                    {name: "overview_provider", label: "Provider"},
+                    {name: "createdDate", label: "Date/Time"}]
 
             }
         }

--- a/apps/publisher/extensions/assets/default/asset.js
+++ b/apps/publisher/extensions/assets/default/asset.js
@@ -216,6 +216,14 @@ asset.configure = function() {
             permissions: {
                 configureRegistryPermissions: function(ctx) {
                 }
+            },
+            sorting: {
+                names: [
+                    {field: "overview_name", label: "Name"},
+                    {field: "overview_version", label: "Version"},
+                    {field: "overview_provider", label: "Provider"},
+                    {field: "createdDate", label: "Date/Time"}]
+
             }
         }
     };

--- a/apps/publisher/modules/page-decorators.js
+++ b/apps/publisher/modules/page-decorators.js
@@ -168,12 +168,12 @@ var pageDecorators = {};
         }
     };
     pageDecorators.sorting = function (ctx, page, fields) {
+        if(page.meta.pageName !== 'list'){
+            return;
+        }
+        var names = ctx.rxtManager.getSortingNames(ctx.assetType);
         var queryString = request.getQueryString();
-        var sortable = fields || [
-            {field:"overview_name",label:"Name"},
-            {field:"overview_version",label:"Version"},
-            {field:"overview_provider",label:"Provider"},
-            {field:"createdDate",label:"Date/Time"}];
+        var sortable = fields || names;
         var sortingList = [];
         var sortingListSelected = {};
         var sortBy = "createdDate";

--- a/apps/publisher/modules/page-decorators.js
+++ b/apps/publisher/modules/page-decorators.js
@@ -171,9 +171,9 @@ var pageDecorators = {};
         if(page.meta.pageName !== 'list'){
             return;
         }
-        var names = ctx.rxtManager.getSortingNames(ctx.assetType);
+        var attributes = ctx.rxtManager.getSortingAttributes(ctx.assetType);
         var queryString = request.getQueryString();
-        var sortable = fields || names;
+        var sortable = fields || attributes;
         var sortingList = [];
         var sortingListSelected = {};
         var sortBy = "createdDate";
@@ -205,7 +205,7 @@ var pageDecorators = {};
             sortObj.active = false;
             sortObj.sortNext = "+";
             sortObj.sortIcon = "sorting_asc";
-            if(sortable[i].field == sortBy) {
+            if(sortable[i].name == sortBy) {
                 if(sort == "+") {
                     sortingListSelected.helpIcon = "fw-sort-up margin-bottom-align";
                     sortObj.sortNext = "-";

--- a/jaggery-modules/rxt/module/scripts/core/core.js
+++ b/jaggery-modules/rxt/module/scripts/core/core.js
@@ -991,6 +991,32 @@ var core = {};
         }
         return false;
     };
+    /**
+     * Returns an Object with a mapping of sortable field name and the corresponding label name.This mapping contains
+     * the fields need to be displayed in the sort dropdown menu in the asset list page.
+     * If the field is not found then null value is returned
+     * @example
+     *     var value = rxtManager.getSortingNames('gadget');
+     * @param  {String} type The RXT type
+     * @return {Object}  The list of sortable fields with their associated label names, available for the give RXT type
+     */
+    RxtManager.prototype.getSortingNames = function(type) {
+        var rxtDefinition = this.rxtMap[type];
+        if (!rxtDefinition) {
+            log.error('Unable to locate the rxt definition for type: ' + type +
+                ' in order to return sortable field names');
+            throw 'Unable to locate the rxt definition for type: ' + type + ' in order to return sortable field names ';
+        }
+        if ((rxtDefinition.meta) && (rxtDefinition.meta.sorting) && (rxtDefinition.meta.sorting.names)) {
+            return rxtDefinition.meta.sorting.names;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug('Unable to locate sortable field names for type: ' + type +
+                '.Check if a sortable field names property is defined in the rxt configuration.');
+        }
+        return null;
+    };
+
     var getFieldNameParts = function(fieldName) {
         //Break the field by the _
         var components = fieldName.split('_');

--- a/jaggery-modules/rxt/module/scripts/core/core.js
+++ b/jaggery-modules/rxt/module/scripts/core/core.js
@@ -994,27 +994,27 @@ var core = {};
     /**
      * Returns an Object with a mapping of sortable field name and the corresponding label name.This mapping contains
      * the fields need to be displayed in the sort dropdown menu in the asset list page.
-     * If the field is not found then null value is returned
+     * If the field is not found then an empty array is returned
      * @example
      *     var value = rxtManager.getSortingNames('gadget');
      * @param  {String} type The RXT type
      * @return {Object}  The list of sortable fields with their associated label names, available for the give RXT type
      */
-    RxtManager.prototype.getSortingNames = function(type) {
+    RxtManager.prototype.getSortingAttributes = function(type) {
         var rxtDefinition = this.rxtMap[type];
         if (!rxtDefinition) {
             log.error('Unable to locate the rxt definition for type: ' + type +
                 ' in order to return sortable field names');
             throw 'Unable to locate the rxt definition for type: ' + type + ' in order to return sortable field names ';
         }
-        if ((rxtDefinition.meta) && (rxtDefinition.meta.sorting) && (rxtDefinition.meta.sorting.names)) {
-            return rxtDefinition.meta.sorting.names;
+        if ((rxtDefinition.meta) && (rxtDefinition.meta.sorting) && (rxtDefinition.meta.sorting.attributes)) {
+            return rxtDefinition.meta.sorting.attributes;
         }
         if (log.isDebugEnabled()) {
             log.debug('Unable to locate sortable field names for type: ' + type +
                 '.Check if a sortable field names property is defined in the rxt configuration.');
         }
-        return null;
+        return [];
     };
 
     var getFieldNameParts = function(fieldName) {


### PR DESCRIPTION
In this PR:

* Move sorting name fields object to default asset `asset.js`
* Add new method to `RxtManager` to get the sorting name field from above mentioned location
* Update `sorting` page decorator to work with above changes,add filter to execute `sorting` decorator only on `list` page

Addresses the following issue: [STORE-1321](https://wso2.org/jira/browse/STORE-1321)