### PR TITLE
STORE-967 - Appending search/filter queries to the sort request

### DIFF
--- a/apps/store/modules/page-decorators.js
+++ b/apps/store/modules/page-decorators.js
@@ -478,6 +478,7 @@ var pageDecorators = {};
         }
         var sortBy = ctx.rxtManager.getTimeStampAttribute(ctx.assetType);
         var sort = "DESC";
+        var query;
         var sortingList = [];
         var sortingListSelected = {};
 
@@ -488,6 +489,8 @@ var pageDecorators = {};
             sortBy = match ? match[1] : sortBy;
             match = queryString.match(/sort=([^&;]+)/);
             sort = match ? match[1] : sort;
+            match = queryString.match(/q=([^&;]+)/);
+            query = match ? match[0] : match;
         }
         for (var attribute in attributes) {
             if (attributes.hasOwnProperty(attribute)) {
@@ -518,6 +521,7 @@ var pageDecorators = {};
                     sortObj.sortNext = "ASC";
                     sortObj.sortIcon = "sorting_asc";
                 }
+                sortObj.query = query;
                 sortingList.push(sortObj);
             }
         }

--- a/apps/store/themes/store/partials/sort-assets.hbs
+++ b/apps/store/themes/store/partials/sort-assets.hbs
@@ -20,7 +20,7 @@
                                         <li><a
                                                 data-column="@index"
                                                 class="{{#if active}}{{sortIcon}} active {{/if}} {{sortBy.label}}"
-                                                href='{{tenantedUrl ""}}/assets/{{../rxt.shortName}}/list?sortBy={{sortBy.name}}&sort={{sortNext}}'
+                                                href='{{tenantedUrl ""}}/assets/{{../rxt.shortName}}/list?sortBy={{sortBy.name}}&sort={{sortNext}}&{{query}}'
                                         >
                                             {{sortBy.label}}
                                         </a>


### PR DESCRIPTION
This PR is related to [STORE-967](https://wso2.org/jira/browse/STORE-967)

* The issue occurs because the search query is not appended to the sort request. This PR solves this issue. 

* But when a property-based search is involved, sort does not work properly. A related issue was created [REGISTRY-3634](https://wso2.org/jira/browse/REGISTRY-3634) to track this issue.