### PR TITLE
Improvements to SAML response validation

### DIFF
--- a/apps/publisher/config/publisher.json
+++ b/apps/publisher/config/publisher.json
@@ -53,10 +53,12 @@
                 "attributes": {
                     "issuer": "publisher",
                     "identityProviderURL": "%https.host%/samlsso",
-                    "responseSigningEnabled": "true",
-                    "acs": "%https.host%/publisher/acs",
+                    "responseSigningEnabled": true,
+                    "acs": "https://localhost:9443/publisher/acs",
                     "identityAlias": "wso2carbon",
-                    "useTenantKey": false
+                    "defaultNameIDPolicy": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                    "useTenantKey": false,
+                    "isPassive":false
                 }
             },
             "basic": {

--- a/apps/publisher/controllers/acs.jag
+++ b/apps/publisher/controllers/acs.jag
@@ -46,7 +46,6 @@
         var MultitenantUtils = Packages.org.wso2.carbon.utils.multitenancy.MultitenantUtils;
         var MultitenantConstants = Packages.org.wso2.carbon.base.MultitenantConstants;
         var TenantAxisUtils = Packages.org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils;
-
         var service;
         var ctx;
         var domain = MultitenantUtils.getTenantDomain(username);
@@ -62,81 +61,69 @@
         sso_sessions = application.get('sso_sessions');
     }
 
-    if (samlResponse != null) {
+    //Handle SSO login and logout
+    if (samlResponse) {
         samlRespObj = sso.client.getSamlObject(samlResponse);
+        //If response signing is enabled we  to validate it before performing
+        //login or logout operations
+        if (attr.responseSigningEnabled && !sso.client.validateSignature(samlRespObj, keyStoreProps)) {
+            log.error('SAML response object validation failure.');
+            response.sendError(401, 'You do not have permission to login to this application.Please contact your administrator and request permission.');
+            return;
+        }
+
         if (!sso.client.isLogoutResponse(samlRespObj)) {
 
-            // validating the signature
-            if (attr.responseSigningEnabled) {
+            var sessionObj = sso.client.decodeSAMLLoginResponse(samlRespObj, samlResponse, sessionId);
 
-                if (sso.client.validateSignature(samlRespObj, keyStoreProps)) {
-                    var sessionObj = sso.client.decodeSAMLLoginResponse(samlRespObj, samlResponse, sessionId);
+            if ((!sessionObj) && (!sessionObj.sessionIndex)) {
+                log.error('Unable to locate sessionIndex in SAML session object');
+                response.sendError(401, 'You do not have permission to login to this application.Please contact your administrator and request permission.');
+                return;
+            }
+            loadTenant(sessionObj.loggedInUser);
+            session.put("LOGGED_IN_USER", sessionObj.loggedInUser);
+            session.put("Loged", "true");
 
-                    if (sessionObj.sessionIndex != null || sessionObj.sessionIndex != 'undefined') {
-                        loadTenant(sessionObj.loggedInUser);
-                        session.put("LOGGED_IN_USER", sessionObj.loggedInUser);
-                        session.put("Loged", "true");
+            log.info("[PUB] session index :: " + sessionObj.sessionIndex);
+            log.info("[PUB] session :: " + sessionObj.sessionId);
+            log.info("[PUB] real session :: " + session.getId());
 
-                        //sso_sessions[sessionObj.sessionIndex] = sessionObj.sessionId;
+            sso_sessions[sessionObj.sessionId] = sessionObj.sessionIndex;
+            var user = require('store').user;
+            var username = sessionObj.loggedInUser;
+            user.loadTenant(username);
 
-                        log.info("[PUB] session index :: " + sessionObj.sessionIndex);
-                        log.info("[PUB] session :: " + sessionObj.sessionId);
-                        log.info("[PUB] real session :: " + session.getId());
+            var permissionAPI = require('rxt').permissions;
+            var carbon = require('carbon');
+            var usr = carbon.server.tenantUser(username);
+            var modifiedUsername = user.removeTenantDomainFromUsername(username);
+            var hasPublisherLoginPermission = permissionAPI.hasAppPermission('APP_LOGIN', usr.tenantId,
+                modifiedUsername);
+            sso.client.login(sessionObj.sessionIndex, 'publisher', session);
 
-
-                        //sso_sessions[sso_sessions[sessionObj.sessionIndex] = sessionObj.sessionId] = sessionObj.sessionIndex;
-
-                        sso_sessions[sessionObj.sessionId] = sessionObj.sessionIndex;
-
-                        var user = require('store').user;
-
-                        var username = sessionObj.loggedInUser;
-                        user.loadTenant(username)
-
-                        var permissionAPI = require('rxt').permissions;
-                        var carbon = require('carbon');
-                        var usr = carbon.server.tenantUser(username);
-                        var modifiedUsername = user.removeTenantDomainFromUsername(username);
-                        var hasPublisherLoginPermission = permissionAPI.hasAppPermission('APP_LOGIN', usr.tenantId,
-                                modifiedUsername);
-                        sso.client.login(sessionObj.sessionIndex,'publisher',session);
-
-                        if (hasPublisherLoginPermission) {
-                            user.emitLogin(username)
-                            log.debug('user is set :::' + username);
-                            response.sendRedirect(relayState ? relayState : context);
-                        }
-                        else{
-                            //session.invalidate();
-                            log.warn('User '+sessionObj.loggedInUser+' does not have permission to access the publisher application.Make sure the user has the publisher role.');
-                            response.sendError(401,'You do not have permission to login to this application.Please contact your administrator and request permission.');
-                        }
-
-                    }
-                }
+            if (hasPublisherLoginPermission) {
+                user.emitLogin(username);
+                log.debug('user is set :::' + username);
+                response.sendRedirect(relayState ? relayState : context);
+            } else {
+                log.warn('User ' + sessionObj.loggedInUser + ' does not have permission to access the publisher application.Make sure the user has the publisher role.');
+                response.sendError(401, 'You do not have permission to login to this application.Please contact your administrator and request permission.');
             }
 
         } else {
             log.info(' [PUB] PUB SAML LOGOUT RESPONSE, LOCAL SESSION ' + session.getId());
-            //session.invalidate();
-            sso.client.logout(session,'publisher');
+            sso.client.logout(session, 'publisher');
             response.sendRedirect(context);
         }
     }
 
-    // if saml request is a log out request, then invalidate session.
-    if (samlRequest != null) {
-
+    //Handle SLO  requests
+    if (samlRequest) {
         var index = sso.client.decodeSAMLLogoutRequest(sso.client.getSamlObject(samlRequest));
         log.info('PUB BACKEND LOGOUT RECIEVED FROM IDP THE INDEX IS ######' + index + ', LOCAL SESSION: ' + session.getId());
-
         var jSessionId = application.get('sso_sessions')[index];
-
         delete application.get('sso_sessions')[index];
-
-        //sso.client.logout(index);
-        //log.debug('portal Session Id :::' + jSessionId);
-        //session.invalidate();
         sso.client.logout(index, new java.lang.String('publisher'));
     }
 }());

--- a/apps/publisher/extensions/app/publisher-common/pages/sso-auth-login-controller.jag
+++ b/apps/publisher/extensions/app/publisher-common/pages/sso-auth-login-controller.jag
@@ -25,8 +25,18 @@
     var referer=require('utils').request.getReferer(request);//request.getHeader('referer');
     var ignoreReferer = request.getParameter("ignoreReferer");
     var attr = config.authentication.methods.sso.attributes;
-    var encodedSAMLAuthRequest = sso.client.getEncodedSAMLAuthRequest(attr.issuer);
     var log = new Log();
+    var carbon = require('carbon');
+    var superTenant = carbon.server.superTenant;
+    var encodedSAMLAuthRequest;
+    if (attr.responseSigningEnabled) {
+        encodedSAMLAuthRequest = sso.client.getEncodedSignedSAMLAuthRequest(attr.issuer,
+            attr.identityProviderURL, attr.acs, attr.isPassive,
+            superTenant.tenantId, superTenant.domain, attr.defaultNameIDPolicy);
+    } else {
+        encodedSAMLAuthRequest = sso.client.getEncodedSAMLAuthRequest(attr.issuer);
+    }
+
     var postUrl = attr.identityProviderURL;
     if(log.isDebugEnabled()) {
         log.debug('Login URL: '+postUrl);

--- a/apps/publisher/extensions/app/publisher-common/pages/sso-auth-logout-controller.jag
+++ b/apps/publisher/extensions/app/publisher-common/pages/sso-auth-logout-controller.jag
@@ -30,13 +30,22 @@
                 sso_sessions = application.get('sso_sessions'),
                 sessionId = session.getId(),
                 attr = config.authentication.methods.sso.attributes,
-                encodedSAMLLogoutRequest = sso.client.getEncodedSAMLLogoutRequest(user, sso_sessions[session.getId()], attr.issuer),
+                encodedSAMLLogoutRequest = null,
+                idpSessionIndex = sso_sessions[session.getId()],
+                carbon = require('carbon'),
+                superTenant = carbon.server.superTenant,
                 postUrl = attr.identityProviderURL,
                 ignoreReferer = request.getParameter("ignoreReferer"),
                 relayState = request.getHeader('referer') ? request.getHeader('referer') : caramel.configs().context;
 
         relayState = (!ignoreReferer) ? relayState : context + '/login?ignoreReferer=true';
 
+        if(attr.responseSigningEnabled) {
+          encodedSAMLLogoutRequest = sso.client.getEncodedSignedSAMLLogoutRequest(user, idpSessionIndex, attr.issuer,
+            superTenant.tenantId, superTenant.domain, attr.identityProviderURL, attr.defaultNameIDPolicy);
+        } else {
+          encodedSAMLLogoutRequest = sso.client.getEncodedSAMLLogoutRequest(user, idpSessionIndex, attr.issuer);
+        }
         log.debug("portal session index : " + sso_sessions[session.getId()]);
         //session.invalidate();
         %>

--- a/apps/store/config/store.json
+++ b/apps/store/config/store.json
@@ -30,10 +30,12 @@
                 "attributes": {
                     "issuer": "store",
                     "identityProviderURL": "%https.host%/samlsso",
-                    "responseSigningEnabled": "true",
-                    "acs": "%https.host%/store/acs",
+                    "responseSigningEnabled": true,
+                    "acs": "https://localhost:9443/store/acs",
                     "identityAlias": "wso2carbon",
-                    "useTenantKey": false
+                    "defaultNameIDPolicy": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                    "useTenantKey": false,
+                    "isPassive":false
                 }
             },
             "basic": {

--- a/apps/store/controllers/acs.jag
+++ b/apps/store/controllers/acs.jag
@@ -69,76 +69,66 @@
         sso_sessions = application.get('sso_sessions');
     }
 
-    if (samlResponse != null) {
+    if (samlResponse) {
         samlRespObj = sso.client.getSamlObject(samlResponse);
+        //If response signing is enabled we  to validate it before performing
+        //login or logout operations
+        if (attr.responseSigningEnabled && !sso.client.validateSignature(samlRespObj, keyStoreProps)) {
+            log.error('SAML response object validation failure.');
+            response.sendError(401, 'You do not have permission to login to this application.Please contact your administrator and request permission.');
+            return;
+        }
         if (!sso.client.isLogoutResponse(samlRespObj)) {
 
-            // validating the signature
-            if (attr.responseSigningEnabled) {
+            var sessionObj = sso.client.decodeSAMLLoginResponse(samlRespObj, samlResponse, sessionId);
 
-                if (sso.client.validateSignature(samlRespObj, keyStoreProps)) {
-                    var sessionObj = sso.client.decodeSAMLLoginResponse(samlRespObj, samlResponse, sessionId);
-
-                    if (sessionObj.sessionIndex != null || sessionObj.sessionIndex != 'undefined') {
-                        loadTenant(sessionObj.loggedInUser);
-                        session.put("LOGGED_IN_USER", sessionObj.loggedInUser);
-                        session.put("Loged", "true");
-
-                        log.info('[STORE] session index :: ' + sessionObj.sessionIndex);
-                        log.info('[STORE] session :: ' + sessionObj.sessionId);
-                        log.info('[STORE] real session :: ' + session.getId());
-
-                        sso_sessions[sessionObj.sessionId] = sessionObj.sessionIndex;
-
-                        var user = require('store').user;
-
-                        var username = sessionObj.loggedInUser;
-                        user.loadTenant(username)
-
-                        var permissionAPI = require('rxt').permissions;
-                        var carbon = require('carbon');
-                        var usr = carbon.server.tenantUser(username);
-                        var modifiedUsername = user.removeTenantDomainFromUsername(username);
-                        var hasStoreLoginPermission = permissionAPI.hasAppPermission('APP_LOGIN', usr.tenantId,
-                                modifiedUsername);
-                        
-                        sso.client.login(sessionObj.sessionIndex,'store',session);
-
-                        if (hasStoreLoginPermission) {
-                            user.emitLogin(username)
-                            log.debug('user is set :::' + username);
-                            response.sendRedirect(relayState);
-                        }
-                        else{
-                            //session.invalidate();
-                            log.warn('User '+sessionObj.loggedInUser+' does not have permission to access the store application.Make sure the user has the store role.');
-                            response.sendError(401,'You do not have permission to login to this application.Please contact your administrator and request permission.');
-                        }
-
-                    }
-                }
+            if ((!sessionObj) && (!sessionObj.sessionIndex)) {
+                log.error('Unable to locate sessionIndex in SAML session object');
+                response.sendError(401, 'You do not have permission to login to this application.Please contact your administrator and request permission.');
+                return;
             }
+            loadTenant(sessionObj.loggedInUser);
+            session.put("LOGGED_IN_USER", sessionObj.loggedInUser);
+            session.put("Loged", "true");
 
+            log.info('[STORE] session index :: ' + sessionObj.sessionIndex);
+            log.info('[STORE] session :: ' + sessionObj.sessionId);
+            log.info('[STORE] real session :: ' + session.getId());
+
+            sso_sessions[sessionObj.sessionId] = sessionObj.sessionIndex;
+            var user = require('store').user;
+            var username = sessionObj.loggedInUser;
+            user.loadTenant(username);
+
+            var permissionAPI = require('rxt').permissions;
+            var carbon = require('carbon');
+            var usr = carbon.server.tenantUser(username);
+            var modifiedUsername = user.removeTenantDomainFromUsername(username);
+            var hasStoreLoginPermission = permissionAPI.hasAppPermission('APP_LOGIN', usr.tenantId,
+                modifiedUsername);
+            sso.client.login(sessionObj.sessionIndex, 'store', session);
+
+            if (hasStoreLoginPermission) {
+                user.emitLogin(username);
+                log.debug('user is set :::' + username);
+                response.sendRedirect(relayState);
+            } else {
+                log.warn('User ' + sessionObj.loggedInUser + ' does not have permission to access the store application.Make sure the user has the store role.');
+                response.sendError(401, 'You do not have permission to login to this application.Please contact your administrator and request permission.');
+            }
         } else {
             log.info('[STORE] SAML LOGOUT RESPONSE , LOCAL SESSION: ' + session.getId());
-            //session.invalidate();
-            sso.client.logout(session,'store');
+            sso.client.logout(session, 'store');
             response.sendRedirect(relayState);
         }
     }
 
-    // if saml request is a log out request, then invalidate session.
-    if (samlRequest != null) {
+    //Handle SLO  requests
+    if (samlRequest) {
         var index = sso.client.decodeSAMLLogoutRequest(sso.client.getSamlObject(samlRequest));
-        log.info('STORES BACKEND LOGOUT RECIEVED FROM IDP THE INDEX IS ######' + index + ', LOCAL SESSION: ' + session.getId());
-
+        log.info('[STORE] BACKEND LOGOUT RECIEVED FROM IDP THE INDEX IS ######' + index + ', LOCAL SESSION: ' + session.getId());
         var jSessionId = application.get('sso_sessions')[index];
-
         delete application.get('sso_sessions')[index];
-        //sso.client.logout(index);
-        //log.debug('store Session Id :::' + jSessionId);
-
-        //session.invalidate();
         sso.client.logout(index, new java.lang.String('store'));
         log.info('[STORE] Successfully logged out.');
     }

--- a/apps/store/extensions/app/store-common/pages/sso-auth-login-controller.jag
+++ b/apps/store/extensions/app/store-common/pages/sso-auth-login-controller.jag
@@ -25,28 +25,32 @@
             attr = configs.authentication.methods.sso.attributes,
             referer = request.getHeader("referer"),
             ignoreReferer = request.getParameter("ignoreReferer");
-
-    if (referer)
-    {
-        //var host = request.getHeader("Host");
+    var relayState = (referer ? referer : '/store');
+    var encodedSAMLAuthRequest;
+    var log = new Log();
+    var carbon = require('carbon');
+    var superTenant = carbon.server.superTenant;
+    if (referer) {
         var host = referer.split('/')[2];
         referer = referer.split(host)[1];
     }
     if(ignoreReferer){
         referer = null;
     }
-    var relayState = (referer ? referer : '/store');
     session.put('initUrl', relayState);
     //TODO: need to parameterize default value in order to support app renaming
-
-            var encodedSAMLAuthRequest = sso.client.getEncodedSAMLAuthRequest(attr.issuer);
-            var log = new Log();
-            var postUrl = attr.identityProviderURL;
-            if(log.isDebugEnabled()){
-                log.debug('Login URL: '+postUrl);
-            }
+    var postUrl = attr.identityProviderURL;
+    if(log.isDebugEnabled()){
+      log.debug('Login URL: '+postUrl);
+    }
     session.remove("Loged");
-    var log = new Log();
+    if (attr.responseSigningEnabled) {
+        encodedSAMLAuthRequest = sso.client.getEncodedSignedSAMLAuthRequest(attr.issuer,
+            attr.identityProviderURL, attr.acs, attr.isPassive,
+            superTenant.tenantId, superTenant.domain, attr.defaultNameIDPolicy);
+    } else {
+        encodedSAMLAuthRequest = sso.client.getEncodedSAMLAuthRequest(attr.issuer);
+    }
     log.info("[STORE] LOGIN URL: " + postUrl);
     log.info('[STORE] Initiating login request from ' + session.getId());
     if (!session.get("Loged")) {

--- a/apps/store/extensions/app/store-common/pages/sso-auth-logout-controller.jag
+++ b/apps/store/extensions/app/store-common/pages/sso-auth-logout-controller.jag
@@ -23,6 +23,7 @@
     var relayState = request.getHeader('referer') ? request.getHeader('referer') : caramel.configs().context;
     var ignoreReferer = request.getParameter("ignoreReferer");
     var rxt = require("rxt");
+    var log = new Log();
     var context = rxt.app.getContext();
     relayState = (!ignoreReferer) ? relayState : context + '/login?ignoreReferer=true';
     if(user === null) {
@@ -32,12 +33,20 @@
                 sso = require('sso'),
                 sso_sessions = application.get('sso_sessions'),
                 sessionId = session.getId(),
+                idpSessionIndex = sso_sessions[session.getId()],
+                carbon = require('carbon'),
+                superTenant = carbon.server.superTenant,
                 attr = config.authentication.methods.sso.attributes,
                 encodedSAMLLogoutRequest = sso.client.getEncodedSAMLLogoutRequest(user, sso_sessions[session.getId()], attr.issuer),
-                //postUrl = "https://" + process.getProperty('carbon.local.ip') + ":" + process.getProperty('https.port');
                 postUrl = attr.identityProviderURL;
-        var log = new Log();
-        log.debug("store session index : " + sso_sessions[session.getId()]);
+
+         if (attr.responseSigningEnabled) {
+             encodedSAMLLogoutRequest = sso.client.getEncodedSignedSAMLLogoutRequest(user, idpSessionIndex, attr.issuer,
+                 superTenant.tenantId, superTenant.domain, attr.identityProviderURL, attr.defaultNameIDPolicy);
+         } else {
+             encodedSAMLLogoutRequest = sso.client.getEncodedSAMLLogoutRequest(user, idpSessionIndex, attr.issuer);
+         }
+         log.debug("store session index : " + idpSessionIndex);
         //session.invalidate();
         %>
         <div>


### PR DESCRIPTION
This PR contains the following changes:
- SAML Requests are now encoded if the responseSigningEnabled property in the publisher.json and store.json are enabled
- Signature validation of SAML Responses sent by the IDP
- Changed the method siganture of the validateSignature method to support logout responses
- Changed the acs property in the store.json and publisher.json to localhost.This is because the acs value is registered with localhost and is used for encoding the SAML request.The acs value encoded in the SAML request and the one registered in the Service Provider configuration must be the same.This change has no effect in the way the request flow.If the Service Provider configuration is changed this value must also be updated.