### PR TITLE
Fix for REGISTRY-3647

### DIFF
--- a/jaggery-modules/rxt/module/scripts/constants/constants.js
+++ b/jaggery-modules/rxt/module/scripts/constants/constants.js
@@ -152,7 +152,7 @@ var constants = {};
     constants.DEFAULT_TAG_PAGIN = {
         start: 0,
         count: 10,
-        sortBy: 'overview_createdtime',
+        sortBy: 'createdDate',
         sortOrder: 'DESC'
     };
 


### PR DESCRIPTION
Changed default sortBy property to createdDate

Addresses the following issue: [REGISTRY-3647](https://wso2.org/jira/browse/REGISTRY-3647)