### PR TITLE
Fix for STORE-1355: Disable image viwer modal when when no image

### DIFF
--- a/apps/publisher/themes/default/js/view-asset.js
+++ b/apps/publisher/themes/default/js/view-asset.js
@@ -1,10 +1,11 @@
 $(document).ready(function () {
     var image = $('.image-display');
     image.click(function () {
+        var noImage = $(this).data().error;
+        if (noImage) {
+            $(this).off('click').css({cursor: 'default'});
+            return false;
+        }
         messages.modal_pop({content: '<img class="img-responsive" src="' + $(this).attr('src') + '" />'});
     });
-    image.error(
-        function () {
-            $(this).unbind("click").css("cursor", "default")
-        });
 });

--- a/apps/publisher/themes/default/partials/default_table.hbs
+++ b/apps/publisher/themes/default/partials/default_table.hbs
@@ -21,8 +21,9 @@
                         {{renderCheckbox value}}
                     {{else}}
                         {{#if_equal this.type "file"}}
-                            <img alt="thumbnail"
+                            <img alt="thumbnail" onerror="this.dataset.error = true"
                                  data-noImage="No {{label}}"
+                                 data-error="false"
                                  class="image-display no-image"
                                  src="{{url ""}}/storage/{{this.assetType}}/{{this.assetId}}/{{this.name.tableQualifiedName}}">
                         {{else}}


### PR DESCRIPTION
In this PR:

* Add new data attribute to thumbnail images to keep error status
* Update JS to check image validity status to prevent loading image modal

Address the following issue : [STORE-1355](https://wso2.org/jira/browse/STORE-1355)