### PR TITLE
Fix for STORE-1347 : Remove copying entry for social app from p2.inf

### DIFF
--- a/features/org.wso2.carbon.es.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.es.feature/resources/p2.inf
@@ -5,6 +5,5 @@ org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../d
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.es_${feature.version}/apps/store,target:${installFolder}/../../deployment/server/jaggeryapps/es-store,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.es_${feature.version}/apps/sso,target:${installFolder}/../../deployment/server/jaggeryapps/es-sso,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.es_${feature.version}/apps/publisher,target:${installFolder}/../../deployment/server/jaggeryapps/es-publisher,overwrite:true);\
-org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.es_${feature.version}/apps/social,target:${installFolder}/../../deployment/server/jaggeryapps/es-social,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.es_${feature.version}/resources/dbscripts/,target:${installFolder}/../../../dbscripts,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.es_${feature.version}/resources/repository/,target:${installFolder}/../../../repository,overwrite:true);\


### PR DESCRIPTION
Update es.feature p2.inf to prevent copying social app when building the product.