### PR TITLE
Fix for REGISTRY-3677, 3682, 3683

### DIFF
--- a/apps/publisher/themes/default/js/create_asset.js
+++ b/apps/publisher/themes/default/js/create_asset.js
@@ -202,7 +202,10 @@ $(function () {
     };
 
     $('#btn-create-asset').click(function (e) {
-        $('#taxonomy-list')[0].value = selectedTaxonomy.join(',');
+        var taxonomyList = $('#taxonomy-list')[0];
+        if (selectedTaxonomy && taxonomyList) {
+            taxonomyList.value = selectedTaxonomy.join(',');
+        }
     });
 
     $('button[type=reset]').click(function (e) {

--- a/apps/publisher/themes/default/js/taxonomy-view-asset.js
+++ b/apps/publisher/themes/default/js/taxonomy-view-asset.js
@@ -21,6 +21,9 @@ $(function () {
                     }
                     displayValue.length = 0;
                 }
+            } else {
+                $('.selected-taxonomy-container').hide();
+                $('#taxonomy').append('<div id="no-table-data"><b>No taxonomy data available</b></div>');
             }
         }
     });

--- a/apps/publisher/themes/default/js/taxonomy-view-asset.js
+++ b/apps/publisher/themes/default/js/taxonomy-view-asset.js
@@ -21,6 +21,7 @@ $(function () {
                     }
                     displayValue.length = 0;
                 }
+                $('#taxonomy').collapse('show');
             } else {
                 $('.selected-taxonomy-container').hide();
                 $('#taxonomy').append('<div id="no-table-data"><b>No taxonomy data available</b></div>');

--- a/apps/publisher/themes/default/js/update_asset.js
+++ b/apps/publisher/themes/default/js/update_asset.js
@@ -199,7 +199,10 @@ $(function() {
     });
 
     $('#editAssetButton').click(function (e) {
-        $('#taxonomy-list')[0].value = selectedTaxonomy.join(',');
+        var taxonomyList = $('#taxonomy-list')[0];
+        if (selectedTaxonomy && taxonomyList) {
+            taxonomyList.value = selectedTaxonomy.join(',');
+        }
     });
 
     $('input[type=reset]').click(function (e) {


### PR DESCRIPTION
This PR includes following fixes, 
* Fixing thrown JS error when creating assets without taxonomy available.
* Showing no-table data in asset overview page when no taxonomy is applied to the asset
* Open taxonomy display by default if applied taxonomy available.