### PR TITLE
Fix to remove expression in case: a&&b

### DIFF
--- a/apps/store/themes/store/js/taxonomy-syntax-api.js
+++ b/apps/store/themes/store/js/taxonomy-syntax-api.js
@@ -95,7 +95,7 @@ var TaxonomySyntaxAPI = {};
         var removeIndex = -1;
         //Check if there is only one operand
         if (this.hasOnlyOneOperand(operand)) {
-            removeIndex = this.operandAtIndex(operand);
+            removeIndex = this.operandIndex(operand);
             this.expression.operands.splice(removeIndex, 1);
         } else {
             //Find and remove the exact match


### PR DESCRIPTION
	Fixed an issue with taxonomy syntax not been removed in the following case: a && b