### PR TITLE
Fix for Registry 3399: Malfunction on likes and dislikes counting

### DIFF
--- a/apps/store/extensions/app/social-reviews/modules/reviews-utils.js
+++ b/apps/store/extensions/app/social-reviews/modules/reviews-utils.js
@@ -61,13 +61,17 @@ var ReviewUtils = {};
         var myIndex;
         for (var index = 0; index < reviews.length; index++) {
             review = reviews[index];
+            review.user = false;
             usernameOnReview = review.actor.id;
+            var targetId = String(review.object.id);
             review.actor.id = cleanUsername(review.actor.id);
             review.isMyComment = (usernameOnReview === formatUsername(user));
             //Only populate review details if there is a logged in
             //user
             if (user && review.isMyComment) {
                 myIndex = index;
+            } else if (user) {
+                review.user = true;
             }
         }
         if (myIndex !== undefined) {
@@ -96,10 +100,10 @@ var ReviewUtils = {};
         var reviewJSON = JSON.stringify(review);
         var username = review.actor.id;
         var target = review.target.id;
-        var reviewed = socialSvc.isReviewed(target, username);
+        var alreadyPublished = socialSvc.isPublished(reviewJSON, target, username);
         var result = {};
         var id = -1;
-        if (!reviewed) {
+        if (!alreadyPublished) {
             id = socialSvc.publish(reviewJSON);
         }
         result.id = id;

--- a/apps/store/extensions/app/social-reviews/themes/store/js/custom/review.js
+++ b/apps/store/extensions/app/social-reviews/themes/store/js/custom/review.js
@@ -139,6 +139,9 @@ $container.on('click', '#btn-post', function (e) {
     }
 });
 $stream.on('click', '.icon-thumbs-down', function (e) {
+    if (!store.user) {
+        return false;
+    }
     e.preventDefault();
     var $tDownBtn = $(e.target);
     var $review = $tDownBtn.parents('.com-review');
@@ -180,6 +183,9 @@ $stream.on('click', '.icon-thumbs-down', function (e) {
     }
 });
 $stream.on('click', '.icon-thumbs-up', function (e) {
+    if (!store.user) {
+        return false;
+    }
     e.preventDefault();
     var $tUpBtn = $(e.target);
     var $review = $tUpBtn.parents('.com-review');

--- a/apps/store/extensions/app/social-reviews/themes/store/partials/activity.hbs
+++ b/apps/store/extensions/app/social-reviews/themes/store/partials/activity.hbs
@@ -25,25 +25,31 @@
                 <ul>
                     <li>
                         {{#unless isMyComment}}
+                            {{#if user}}
                             <a href="#">
                                 <i class="icon icon-thumbs-up {{#if iLike}}selected{{/if}}"></i><span
                                     class="com-like-count">{{#if object.likes.totalItems}} {{object.likes.totalItems}} {{/if}}</span></a>
+                            {{else}}
+                                <i class="icon icon-thumbs-up"></i><span
+                                    >{{#if object.likes.totalItems}} {{object.likes.totalItems}} {{/if}}</span>
+                            {{/if}}
                         {{else}}
                             <i class="icon icon-thumbs-up {{#if iLike}}selected{{/if}}"></i><span
-                                class="com-like-count">{{#if object.likes.totalItems}} {{object.likes.totalItems}} {{/if}}</span>
+                                >{{#if object.likes.totalItems}} {{object.likes.totalItems}} {{/if}}</span>
                         {{/unless}}
-
                     </li>
                     <li>
-
-
                         {{#unless isMyComment}}
+                            {{#if user}}
                             <a href="#"><i class="icon icon-thumbs-down {{#if iDislike}}selected{{/if}}"></i><span
                                     class="com-dislike-count">{{#if object.dislikes.totalItems}} {{object.dislikes.totalItems}} {{/if}}</span></a>
-
+                            {{else}}
+                                <i class="icon icon-thumbs-down"></i><span
+                            >{{#if object.dislikes.totalItems}} {{object.dislikes.totalItems}} {{/if}}</span>
+                            {{/if}}
                         {{else}}
                             <i class="icon icon-thumbs-down {{#if iDislike}}selected{{/if}}"></i><span
-                                class="com-dislike-count">{{#if object.dislikes.totalItems}} {{object.dislikes.totalItems}} {{/if}}</span>
+                              >{{#if object.dislikes.totalItems}} {{object.dislikes.totalItems}} {{/if}}</span>
                         {{/unless}}
                     </li>
                 </ul>

--- a/components/social/org.wso2.carbon.social.core/src/main/java/org/wso2/carbon/social/core/Activity.java
+++ b/components/social/org.wso2.carbon.social.core/src/main/java/org/wso2/carbon/social/core/Activity.java
@@ -53,4 +53,7 @@ public interface Activity {
 
 	void setComment(String comment);
 
+    void setILike(boolean like);
+
+    void setIDislike(boolean dislike);
 }

--- a/components/social/org.wso2.carbon.social.core/src/main/java/org/wso2/carbon/social/core/ActivityBrowser.java
+++ b/components/social/org.wso2.carbon.social.core/src/main/java/org/wso2/carbon/social/core/ActivityBrowser.java
@@ -42,7 +42,7 @@ public interface ActivityBrowser {
 
 	boolean isUserlikedActivity(String userId, int targetId, int like) throws SocialActivityException;
 
-	boolean isReviewed(String targetId, String userId) throws SocialActivityException;
+	boolean isPublished(String activity, String targetId, String userId) throws SocialActivityException;
 
 	JsonObject pollNewestComments(String targetId, int timestamp) throws SocialActivityException;
 

--- a/components/social/org.wso2.carbon.social.core/src/main/java/org/wso2/carbon/social/core/service/SocialActivityService.java
+++ b/components/social/org.wso2.carbon.social.core/src/main/java/org/wso2/carbon/social/core/service/SocialActivityService.java
@@ -229,8 +229,8 @@ public abstract class SocialActivityService {
 	 * @param userId Username with the tenant domain i:e - admin@carbon.super
 	 *
 	 */
-	public boolean isReviewed(String targetId, String userId) throws SocialActivityException {
-		return getActivityBrowser().isReviewed(targetId, userId);
+	public boolean isPublished(String activity, String targetId, String userId) throws SocialActivityException {
+		return getActivityBrowser().isPublished(activity, targetId, userId);
 	}
 
 	/**

--- a/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/SQLActivity.java
+++ b/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/SQLActivity.java
@@ -125,4 +125,12 @@ public class SQLActivity implements Activity {
 		JsonObject object = (JsonObject) this.body.get("object");
 		object.addProperty("content", comment);
 	}
+
+    public void setILike(boolean like) {
+        this.body.addProperty("iLike", like);
+    }
+
+    public void setIDislike(boolean dislike) {
+        this.body.addProperty("iDislike", dislike);
+    }
 }

--- a/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/SocialUtil.java
+++ b/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/SocialUtil.java
@@ -44,6 +44,12 @@ public class SocialUtil {
 
 	}
 
+    public static String getTenantedUsername() {
+        String username = CarbonContext.getThreadLocalCarbonContext().getUsername();
+        String domain = getTenantDomain();
+        return username + "@" + domain;
+    }
+
 	public static int getActivityLimit(int limit) {
 
 		if (limit > Constants.MAXIMUM_ACTIVITY_SELECT_COUNT || limit == 0) {


### PR DESCRIPTION
In this PR:

* Get total likes(:thumbsup:) and dislikes (:thumbsdown:) count from `SOCIAL_LIKES` table instead of embedding those values to activity body
* Move is `iLike`(:blush:) and `iDislike`(:disappointed:) checks to `listActivities` method in SQLActivityBrowser
* Update ~~`isReviewed`~~ method to check both comments and likes activities, and rename the method as `isPublished`

Address the following issue : [REGISTRY-3399](https://wso2.org/jira/browse/REGISTRY-3399)