### PR TITLE
Fix for REGISTRY-3715 : Fix styling issue in asset info cards

### DIFF
--- a/apps/publisher/themes/default/css/custom.css
+++ b/apps/publisher/themes/default/css/custom.css
@@ -1462,4 +1462,7 @@ a#search-info {
     border-bottom-color: #ECECEC;
 }
 
+.lifecycle-state {
+    display: block;
+}
 /* </Search Option Popover> */

--- a/apps/store/themes/store/css/custom.css
+++ b/apps/store/themes/store/css/custom.css
@@ -1410,6 +1410,7 @@ h2.app-title {
 .ctrl-wr-asset .ast-content {
     background-color: #fff;
     padding-bottom:10px;
+    min-height: 105px;
 }
 
 .ctrl-wr-asset.selected {
@@ -1583,6 +1584,11 @@ span.advanced-search-icons{
     }
     .tags{
         min-width:auto!important;
+    }
+    .ctrl-wr-asset .ast-content {
+        background-color: #fff;
+        padding-bottom:10px;
+        height: 100%;
     }
 }
 .loading-animation-big{


### PR DESCRIPTION
In this PR:

* Make asset attribute info display span block element
* Set minimum height to asset content element to match the height given to `ctrl-wr-asset` class

Address the following issue : [REGISTRY-3715](https://wso2.org/jira/browse/REGISTRY-3715)