### PR TITLE
Fix for REGISTRY-3770 : Use generic SQL syntax to count number of tuples

### DIFF
--- a/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/Constants.java
+++ b/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/Constants.java
@@ -24,6 +24,7 @@ public class Constants {
 	public static final String SOCIAL_COMMENTS_TABLE_NAME = "SOCIAL_COMMENTS";
 	public static final String SOCIAL_RATING_TABLE_NAME = "SOCIAL_RATING";
 	public static final String SOCIAL_LIKES_TABLE_NAME = "SOCIAL_LIKES";
+	public static final String LIKES_COUNT_ALIAS = "likes_count";
 	public static final String SOCIAL_RATING_CACHE_TABLE_NAME = "SOCIAL_RATING_CACHE";
 	
 	public static final String BODY_COLUMN = "body";

--- a/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/SQLActivityBrowser.java
+++ b/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/SQLActivityBrowser.java
@@ -90,7 +90,8 @@ public class SQLActivityBrowser implements ActivityBrowser {
 			+ Constants.LIKE_VALUE_COLUMN + " = ?";
 
     public static final String SELECT_TOTAL_LIKES = "SELECT COUNT("
-            + Constants.CONTEXT_ID_COLUMN + ") FROM "
+            + Constants.CONTEXT_ID_COLUMN + ") AS "
+            + Constants.LIKES_COUNT_ALIAS + " FROM "
             + Constants.SOCIAL_LIKES_TABLE_NAME + " WHERE "
             + Constants.CONTEXT_ID_COLUMN + " = ? AND "
             + Constants.LIKE_VALUE_COLUMN + " = ?";
@@ -748,7 +749,7 @@ public class SQLActivityBrowser implements ActivityBrowser {
             statement.setInt(2, likeValue);
             resultSet = statement.executeQuery();
             if (resultSet.next()) {
-                String resultColumn = "COUNT(" + Constants.CONTEXT_ID_COLUMN + ")";
+                String resultColumn = Constants.LIKES_COUNT_ALIAS;
                 likes = resultSet.getInt(resultColumn);
             }
             resultSet.close();


### PR DESCRIPTION
In this PR:

* Change query which get total likes from SOCIAL_LIKES table use generic SQL syntax
 
Address the following issue : [REGISTRY-3770](https://wso2.org/jira/browse/REGISTRY-3770)