### PR TITLE
Fix for REGISTRY-3794 : Add check for page.asset.version availability

### DIFF
--- a/apps/publisher/extensions/assets/default/asset.js
+++ b/apps/publisher/extensions/assets/default/asset.js
@@ -313,8 +313,9 @@ asset.renderer = function(ctx) {
                 navList.push('Lifecycle', 'btn-lifecycle', util.buildUrl('lifecycle') + '/' + id);
             }
         }
-        if (permissionAPI.hasActionPermissionforPath(path, 'write', ctx.session) && permissionAPI.hasAssetPagePermission(type,'update',user.tenantId,username)) {
-           navList.push('Version', 'btn-copy', util.buildUrl('copy') + '/' + id);
+        if (permissionAPI.hasActionPermissionforPath(path, 'write', ctx.session)
+            && permissionAPI.hasAssetPagePermission(type, 'update', user.tenantId, username) && page.assets.version) {
+            navList.push('Version', 'btn-copy', util.buildUrl('copy') + '/' + id);
         }
 
         return navList.list();


### PR DESCRIPTION
In this PR:

* Add filter to check whether the version attribute is available in the RXT, If not prevent rendering version tag in publisher app

Address the following issue : [REGISTRY-3794](https://wso2.org/jira/browse/REGISTRY-3794)