### PR TITLE
Fix for REGISTRY-3819 : Tag cloud in detais page, only show tags which are associated with asset

### DIFF
--- a/apps/store/modules/page-decorators.js
+++ b/apps/store/modules/page-decorators.js
@@ -421,6 +421,9 @@ var pageDecorators = {};
         if((page.meta.pageName === 'details')&&(page.assets.id)){
             page.appliedTags = appliedTags(resources.am,page.assets.id);
         }
+        if ((page.appliedTags && page.appliedTags.length > 0) || page.meta.pageName === 'list') {
+            page.showTagCloud = true;
+        }
         var mytags = doTermSearch(ctx,'tags', paging, true);
         var assetTags = page.appliedTags || [];
         var retTags = [];

--- a/apps/store/themes/store/partials/navigation.hbs
+++ b/apps/store/themes/store/partials/navigation.hbs
@@ -81,9 +81,11 @@
             </nav>
 	</div>
             {{#if tags}}
-                <div class="tags-wrapper" id="tags-wrapper">
-                    {{> tag-cloud . }}
-                </div>
+                {{#if showTagCloud}}
+                    <div class="tags-wrapper" id="tags-wrapper">
+                        {{> tag-cloud . }}
+                    </div>
+                {{/if}}
             {{/if}}
     </div>
 </div>

--- a/apps/store/themes/store/partials/tag-cloud.hbs
+++ b/apps/store/themes/store/partials/tag-cloud.hbs
@@ -1,25 +1,43 @@
 <div class="tag-title"> Tags</div>
 <div id="tag-container" class="tag-content">
-    {{#each tags}}
-        {{#if this.selected}}
+    {{#if appliedTags }}
+        {{#each appliedTags}}
             {{#if ../../assetCategoryDetails.hasCategories}}
-                <a  href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><span
-                        class="es-remove-tag text-muted">{{this.value}}</span><i class="es-remove-tag  fw fw-cancel"></i></a>
+                <a href='{{tenantedUrl ""}}/assets/{{ ../../assets/type}}/list?q="category":"{{../../assetCategoryDetails.selectedCategory}}","tags":"{{this}}"'>
+                    <span class="es-applied-tag text-muted">{{this}}</span>
+                </a>
             {{else}}
-                <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'><span
-                        class="es-remove-tag text-muted" >{{this.value}}</span><i class="es-remove-tag  fw fw-cancel"></i></a>
-            {{/if}}
-        {{else}}
-            {{#if ../../assetCategoryDetails.hasCategories}}
-                <a class='es-add-tag' href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><span class='es-add-tag' data-selected-tag='{{this.value}}'>
-                {{this.value}}</span></a>
-            {{else}}
-                <a class='es-add-tag' href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'>
-                    <span class='es-add-tag' data-selected-tag='{{this.value}}'>{{this.value}}</span>
+                <a href='{{tenantedUrl ""}}/assets/{{ ../../assets/type}}/list?q="tags":"{{this}}"'>
+                    <span class="es-applied-tag text-muted">{{this}}</span>
                 </a>
             {{/if}}
-        {{/if}}
-    {{/each}}
+        {{/each}}
+    {{else}}
+        {{#each tags}}
+            {{#if this.selected}}
+                {{#if ../../assetCategoryDetails.hasCategories}}
+                    <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><span
+                            class="es-remove-tag text-muted">{{this.value}}</span><i
+                            class="es-remove-tag  fw fw-cancel"></i></a>
+                {{else}}
+                    <a href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'><span
+                            class="es-remove-tag text-muted">{{this.value}}</span><i
+                            class="es-remove-tag  fw fw-cancel"></i></a>
+                {{/if}}
+            {{else}}
+                {{#if ../../assetCategoryDetails.hasCategories}}
+                    <a class='es-add-tag'
+                       href='{{tenantedUrl ""}}{{this.searchPage}}?q="category":"{{../../../assetCategoryDetails.selectedCategory}}","tags":"{{this.value}}"'><span
+                            class='es-add-tag' data-selected-tag='{{this.value}}'>
+                        {{this.value}}</span></a>
+                {{else}}
+                    <a class='es-add-tag' href='{{tenantedUrl ""}}{{this.searchPage}}?q="tags":"{{this.value}}"'>
+                        <span class='es-add-tag' data-selected-tag='{{this.value}}'>{{this.value}}</span>
+                    </a>
+                {{/if}}
+            {{/if}}
+        {{/each}}
+    {{/if}}
 </div>
 <div id="tags-collapse" class="tags-collapse">
     <p class="small">


### PR DESCRIPTION
In this PR:

* Show tag cloud only in list asset page and details page when the associated asset having tags with it

Address the following issue: [REGISTRY-3819](https://wso2.org/jira/browse/REGISTRY-3819)