### PR TITLE
Fix for REGISTRY-3819 : Remove commented isSelected check

### DIFF
--- a/apps/store/modules/page-decorators.js
+++ b/apps/store/modules/page-decorators.js
@@ -723,18 +723,18 @@ var pageDecorators = {};
         log.debug("term search query criteria:facetField " + facetField + " mediaType " + mediaType);
 
         var q = request.getParameter("q");
-/*        if (q) {
+        if (q) {
             var options = parse("{" + q + "}");
-            if (facetField == "tags") {
+            /*if (facetField == "tags") {
                 map = buildQueryMapTags(ctx, options);
             } else {
                 map = buildQueryMap(ctx, options);
-            }
+            }*/
 
             if (options.tags) {
                 selectedTag = options.tags;
             }
-        }*/
+        }
 
         if (facetField) {
             try {


### PR DESCRIPTION
In this PR:

* Remove the comment outed `selectedTag` flag which used to set `selected` status of the tag.

Address the following issue : [REGISTRY-3819](https://wso2.org/jira/browse/REGISTRY-3819)