### PR TITLE
Fixed an issue with parsing taxonomy expressions

### DIFF
--- a/apps/store/themes/store/js/taxonomy-syntax-api.js
+++ b/apps/store/themes/store/js/taxonomy-syntax-api.js
@@ -194,8 +194,7 @@ var TaxonomySyntaxAPI = {};
         //return rprint(this, '', decorator);
         return patch_add_braces(rprint(this, '', decorator));
     };
-
-     /**
+    /**
      * Adding url taxonomy category retrieve options with 2d array
      * @returns {Array}
      */
@@ -204,11 +203,9 @@ var TaxonomySyntaxAPI = {};
         this.operands.forEach(function(value) {
             mainCol.push([value]);
         });
-
         this.children.forEach(function(child) {
             mainCol.push(child.operands);
         });
-
         return mainCol;
     };
 
@@ -222,7 +219,7 @@ var TaxonomySyntaxAPI = {};
             return singleExpression;
         }
         var stack = [];
-        var x = rbuild(symbols, symbols.pop(), new Expression(), stack);
+        var x = rbuild(symbols, symbols.pop(), null, stack);
         var t = processStack(x);
         return t;
     }
@@ -258,6 +255,9 @@ var TaxonomySyntaxAPI = {};
             //stack.push(expression);
             return stack;
         } else if (currentValue === SYMBOL_EXP_START) {
+            if (expression) {
+                stack.push(expression);
+            }
             var newExpression = new Expression();
             newExpression.operator = SYMBOL_AND;
             return rbuild(symbols, symbols.pop(), newExpression, stack);


### PR DESCRIPTION
Fixed an issue with parsing taxonomy expressions when single operands are provided at the start

This PR addresses the following cases:
- Remove b from ( a && ( b OR c ) && d )
- Remove d from ( a && ( b OR c ) && ( d OR e ) )
- Remove b from ( a && ( b OR c ) )
- Remove c from ( a && b && ( c OR d ) && e )