### PR TITLE
Fix for REGISTRY-3845

### DIFF
--- a/apps/publisher/themes/default/js/taxonomy-browser.js
+++ b/apps/publisher/themes/default/js/taxonomy-browser.js
@@ -184,6 +184,9 @@ var getTaxonomyName = function (taxonomyId) {
 var getTaxonomyDisplayName = function (taxonomyPath) {
     var taxonomyPathList = taxonomyPath.split('/');
     var taxonomyName = getTaxonomyName(taxonomyPathList[0]);
+    if (!taxonomyName) {
+        return;
+    }
     displayValue.push(taxonomyName);
     taxonomyPath = taxonomyPathList[0];
     for (var i = 1; i < taxonomyPathList.length; ++i) {
@@ -249,6 +252,9 @@ function initTaxonomyBrowser(appliedTaxonomy) {
             if (appliedTaxonomy.hasOwnProperty(key)) {
                 var element = appliedTaxonomy[key];
                 getTaxonomyDisplayName(element);
+                if (displayValue.length == 0) {
+                    continue;
+                }                
                 if (selectedTaxonomy.indexOf(element) < 0) {
                     selectedTaxonomy.push(appliedTaxonomy[key]);
                     $(SELECTED_CONTENT).append('<div class="selected-item" data-value="' + appliedTaxonomy[key] + '">'

--- a/apps/publisher/themes/default/js/taxonomy-view-asset.js
+++ b/apps/publisher/themes/default/js/taxonomy-view-asset.js
@@ -15,6 +15,9 @@ $(function () {
                     if (appliedTaxonomy.hasOwnProperty(key)) {
                         var element = appliedTaxonomy[key];
                         getTaxonomyDisplayName(element);
+                        if (displayValue.length == 0) {
+                            continue;
+                        }
                         $('.selected-taxonomy-content').append(
                             '<div class="selected-item" style="padding: 12px"><span>'
                             + displayValue.join(' > ') + '</span></div>');


### PR DESCRIPTION
This PR is related with [REGISTRY-3845](https://wso2.org/jira/browse/REGISTRY-3845)

This fixes the issue of displaying empty taxonomy tag which can occur by an RXT modification.