### PR TITLE
Fix un-authenticated user updating review

### DIFF
--- a/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/SQLActivityPublisher.java
+++ b/components/social/org.wso2.carbon.social.sql/src/main/java/org/wso2/carbon/social/sql/SQLActivityPublisher.java
@@ -66,6 +66,14 @@ public class SQLActivityPublisher extends ActivityPublisher {
 			+ " WHERE "
 			+ Constants.ID_COLUMN + " = ?";
 
+	private static final String COMMENT_ACTIVITY_SELECT_FOR_UPDATE_COMMENT_SQL = "SELECT "
+			+ Constants.BODY_COLUMN + " , "
+			+ Constants.ID_COLUMN
+			+ " FROM "
+			+ Constants.SOCIAL_COMMENTS_TABLE_NAME
+			+ " WHERE "
+			+ Constants.ID_COLUMN + " = ? AND " + Constants.USER_COLUMN + " = ?";
+
 	public static final String COMMENT_ACTIVITY_SELECT_SQL = "SELECT "
 			+ Constants.BODY_COLUMN + " FROM "
 			+ Constants.SOCIAL_COMMENTS_TABLE_NAME + " WHERE "
@@ -694,13 +702,15 @@ public class SQLActivityPublisher extends ActivityPublisher {
             connection = DSConnection.getConnection();
             connection.setAutoCommit(false);
             String commentID = updatedActivity.getId();
+            String userID = updatedActivity.getActorId();
 
             if (log.isDebugEnabled()) {
-                log.debug("Executing: " + COMMENT_ACTIVITY_SELECT_FOR_UPDATE_SQL);
+                log.debug("Executing: " + COMMENT_ACTIVITY_SELECT_FOR_UPDATE_COMMENT_SQL);
             }
 
-            selectActivityStatement = connection.prepareStatement(COMMENT_ACTIVITY_SELECT_FOR_UPDATE_SQL);
+            selectActivityStatement = connection.prepareStatement(COMMENT_ACTIVITY_SELECT_FOR_UPDATE_COMMENT_SQL);
             selectActivityStatement.setString(1, commentID);
+            selectActivityStatement.setString(2, userID);
             resultSet = selectActivityStatement.executeQuery();
             if (!resultSet.next()) {
                 String message = "Invalid comment ID: Unable to update comment for : " + commentID;


### PR DESCRIPTION
## Purpose
This PR introduces an additional check to avoid the un-authenticated update of reviews by intercepting the request.

## Goals
Modified the sql to include the user_id, whenever there is a request to update.

## Approach
N/A

## User stories
Bug Fix

## Release note
Fix un-autenticated update of user-review

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage - Integration test cases cannot be updated, since the relevant parent directory uses a very old version of carbon-store

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 16.04, Oracle JDK 1.8
 
## Learning
N/A