### PR TITLE
Fix issue in getting rxt fields from tables

### DIFF
--- a/jaggery-modules/rxt/module/scripts/core/core.js
+++ b/jaggery-modules/rxt/module/scripts/core/core.js
@@ -1210,9 +1210,10 @@ var core = {};
         var components = getFieldNameParts(name);
         tableName = components.tableName;
         fieldName = components.fieldName;
-        //Convert the table and field names to lowercase
-        tableName = tableName ? tableName.toLowerCase() : '';
-        fieldName = fieldName ? fieldName.toLowerCase() : '';
+        //Convert the table and field names to camelcase
+        tableName = tableName ? createCamelCaseName(tableName) : '';
+        fieldName = fieldName ? createCamelCaseName(fieldName) : '';
+
         var field = null;
         if (!template) {
             log.error('Unable to locate the rxt definition for type: ' + type);


### PR DESCRIPTION
This PR fixes the issue https://github.com/wso2/product-greg/issues/898
The issue was due to the rxtMap being created with fields converted to camel case, but the values were trying to be retrieved for fields with lowercase.